### PR TITLE
feat(shopware): add oauth token provider and authenticated requests

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -30,3 +30,9 @@ services:
     App\Integration\Infrastructure\Http\Shopware\ShopwareAdminApiClient:
         arguments:
             $baseUrl: '%integration.adapters.shopware.base_url%'
+
+    App\Integration\Infrastructure\Http\Shopware\ShopwareTokenProvider:
+        arguments:
+            $baseUrl: '%integration.adapters.shopware.base_url%'
+            $clientId: '%env(resolve:SHOPWARE_CLIENT_ID)%'
+            $clientSecret: '%env(resolve:SHOPWARE_CLIENT_SECRET)%'

--- a/src/Command/Integration/ShopwarePingCommand.php
+++ b/src/Command/Integration/ShopwarePingCommand.php
@@ -28,7 +28,7 @@ final class ShopwarePingCommand extends Command
         $this->printResult($output, 'health-check', $health['status'], $health['body']);
 
         // Optional: version endpoint; 401 is fine (reachable but auth required)
-        $version = $this->client->request('GET', '/api/_info/version');
+        $version = $this->client->request('GET', '/api/_info/version', [], [], [], true);
         $this->printResult($output, 'version', $version['status'], $version['body']);
 
         return Command::SUCCESS;

--- a/src/Integration/Infrastructure/Http/Shopware/ShopwareTokenProvider.php
+++ b/src/Integration/Infrastructure/Http/Shopware/ShopwareTokenProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Infrastructure\Http\Shopware;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class ShopwareTokenProvider
+{
+    private ?string $token = null;
+    private int $expiresAt = 0;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly string $baseUrl,
+        private readonly string $clientId,
+        private readonly string $clientSecret,
+        private readonly bool $verifySsl = true,
+    ) {
+    }
+
+    public function getAccessToken(): string
+    {
+        // Cached token still valid? (30s buffer)
+        if ($this->token !== null && time() < ($this->expiresAt - 30)) {
+            return $this->token;
+        }
+
+        $url = rtrim($this->baseUrl, '/') . '/api/oauth/token';
+
+        $response = $this->httpClient->request('POST', $url, [
+            'verify_peer' => $this->verifySsl,
+            'verify_host' => $this->verifySsl,
+            'json' => [
+                'grant_type' => 'client_credentials',
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+            ],
+        ]);
+
+        $status = $response->getStatusCode();
+        $body = $response->getContent(false);
+
+        if ($status < 200 || $status >= 300) {
+            $snippet = trim(mb_substr($body, 0, 300));
+            throw new \RuntimeException("Shopware token request
+            failed ($status): $snippet");
+        }
+
+        $data = json_decode($body, true);
+        if (!is_array($data) || !isset($data['access_token'], $data['expires_in'])) {
+            throw new \RuntimeException('Shopware token response is missing access_token/expires_in');
+        }
+
+        $this->token = (string) $data['access_token'];
+        $this->expiresAt = time() + (int) $data['expires_in'];
+
+        return $this->token;
+    }
+}


### PR DESCRIPTION
Closes #7

## What
- Add `ShopwareTokenProvider` (client credentials) using `/api/oauth/token`
- Extend `ShopwareAdminApiClient` to support authenticated requests (Bearer token)
- Update `integration:shopware:ping` so `/api/_info/version` returns 200 when authenticated

## Verification
```bash
docker compose exec php sh -lc "bin/console integration:shopware:ping"