### PR TITLE
M1.6 – Extend product CSV schema with stock, pricing and active fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ CLI-first Symfony app for integrating external systems via adapters (**Shopware 
 
 - Symfony 6.4 application running in a Docker-based dev stack
 - Shopware Admin API reachable (OAuth token + requests)
-- Minimal CLI commands implemented:
-    - `integration:shopware:ping`
-    - `integration:shopware:products:list`
-    - `integration:shopware:products:create`
+- CLI commands implemented:
+  - `integration:shopware:ping`
+  - `integration:shopware:products:list`
+  - `integration:shopware:products:create`
+  - `integration:shopware:products:import`
+  - `integration:shopware:products:import-csv`
+  - `integration:shopware:products:import-batch`
 - Unit tests (PHPUnit) + static analysis (PHPStan) + CI workflow (GitHub Actions)
 
 ## Project structure (high level)
@@ -25,12 +28,11 @@ CLI-first Symfony app for integrating external systems via adapters (**Shopware 
 - `config/packages/integration.yaml`  
   Integration configuration root (adapter settings)
 - `tests/...`  
-  Unit tests for Shopware client + token provider
+  Unit tests for Shopware client, token provider and product import
 
 ## Configuration
 
 Copy the example env file and adjust values:
-
 ```bash
 cp .env.example .env
 # optional: local overrides
@@ -48,19 +50,16 @@ Shopware adapter configuration keys (bound via env vars and DI):
 ## Running locally (Docker)
 
 Open a shell inside the PHP container:
-
 ```bash
 docker compose exec php sh
 ```
 
 List available Symfony commands:
-
 ```bash
 docker compose exec php sh -lc "bin/console"
 ```
 
 Shopware smoke tests:
-
 ```bash
 docker compose exec php sh -lc "bin/console integration:shopware:ping"
 docker compose exec php sh -lc "bin/console integration:shopware:products:list --limit=5 --page=1"
@@ -68,22 +67,67 @@ docker compose exec php sh -lc "bin/console integration:shopware:products:create
 ```
 
 Install/update dependencies (composer container pattern):
-
 ```bash
-docker compose run --rm composer composer install
-docker compose run --rm composer composer update
+docker compose run --rm composer install
+docker compose run --rm composer update
 ```
+
+## Product CSV import
+
+The CSV import pipeline reads product data from a CSV file and upserts them into Shopware via the Admin API.
+
+### CSV format
+```csv
+productNumber,name,stock,gross,net,taxRate,currency,active
+IMP-101,Imported product 101,10,19.99,16.80,19,EUR,true
+IMP-102,Imported product 102,0,29.99,,19,,false
+IMP-103,Imported product 103,5,9.99,,,,true
+```
+
+**Required fields:** `productNumber`, `name`
+
+**Optional fields and defaults:**
+
+| Field | Default if empty |
+|---|---|
+| `stock` | `0` |
+| `gross` | no price entry sent |
+| `net` | calculated from `gross` + `taxRate` |
+| `taxRate` | `19` |
+| `currency` | `EUR` |
+| `active` | `true` |
+
+A template is available at `resources/import/templates/products_import_template.csv`.
+
+### Single file import
+```bash
+# dry-run: shows what would be imported without writing to Shopware
+docker compose exec php sh -lc "bin/console integration:shopware:products:import-csv \
+  --file=var/import/incoming/products.csv --dry-run"
+
+# real import
+docker compose exec php sh -lc "bin/console integration:shopware:products:import-csv \
+  --file=var/import/incoming/products.csv"
+```
+
+### Batch import
+
+Scans `var/import/incoming/` for files matching `products*.csv` and processes them in order:
+```bash
+docker compose exec php sh -lc "bin/console integration:shopware:products:import-batch"
+docker compose exec php sh -lc "bin/console integration:shopware:products:import-batch --dry-run"
+```
+
+Successfully processed files are moved to `var/import/processed/`, failed files to `var/import/failed/`.
 
 ## Quality checks
 
 Run unit tests:
-
 ```bash
 docker compose exec php sh -lc "vendor/bin/phpunit"
 ```
 
 Run static analysis:
-
 ```bash
 docker compose exec php sh -lc "vendor/bin/phpstan analyse -c phpstan.dist.neon"
 ```
@@ -95,15 +139,29 @@ GitHub Actions runs on PRs and `main`:
 - PHPUnit
 - PHPStan (Symfony container aware; warms up `dev` cache with `debug=true`)
 
-## Roadmap (next)
+## Roadmap
 
-- **M1: Product data pipeline** (start small, then scale)
-    - list/search products via Admin API
-    - create/update products
-    - later: CSV-based imports
+| Milestone | Status |
+|---|---|
+| M0 – Foundation | ✅ complete |
+| M1 – Product import basics | ✅ mostly complete |
+| M1.6 – Extend CSV schema (stock, pricing, active) | ✅ complete |
+| M1.7 – Validation + error report | 🔲 next |
+| M1.8 – Skip-if-unchanged | 🔲 planned |
+| M2 – State & SyncRuns (Doctrine) | 🔲 planned |
+| M3 – Generic write / push | 🔲 planned |
 
 ## Contributing / workflow
 
 - Work in small issues + feature branches
 - Open PRs and squash-merge into `main`
 - Keep changes incremental and easy to review
+```
+
+---
+
+Einspielen, dann der finale Commit für Step 7:
+```
+docs: update README for M1.6 (CSV import schema, commands, roadmap)
+
+Closes #23

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
         "phpunit/phpunit": "^12",
         "symfony/browser-kit": "6.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c23213f4f24599cf738ec44460a4931",
+    "content-hash": "e6c65824e030570b225f40b34c493063",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -3485,6 +3485,62 @@
                 }
             ],
             "time": "2026-02-11T14:48:56+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-phpunit",
+            "version": "2.0.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.32"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^5",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.16"
+            },
+            "time": "2026-02-14T09:05:21+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,7 @@
 includes:
   - vendor/phpstan/phpstan-symfony/extension.neon
+  - vendor/phpstan/phpstan-phpunit/extension.neon
+  - vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
   level: 3

--- a/resources/import/templates/products_import_template.csv
+++ b/resources/import/templates/products_import_template.csv
@@ -1,6 +1,7 @@
 productNumber,name,stock,gross,net,taxRate,currency,active
 IMP-101,Imported product 101,10,19.99,16.80,19,EUR,true
 IMP-102,Imported product 102,0,29.99,25.20,19,EUR,false
-IMP-103,Imported product 103,5,9.99,8.39,,,true
-IMP-104,Imported product 104,25,49.90,41.93,19,,
-IMP-105,Imported product 105,,,12.61,19,EUR,true
+IMP-103,Imported product 103,5,9.99,,,,true
+IMP-104,Imported product 104,25,49.90,,19,,
+IMP-105,Imported product 105,8,24.99,,19,EUR,true
+IMP-106,Imported product 106,15,15.99,,7,EUR,true

--- a/resources/import/templates/products_import_template.csv
+++ b/resources/import/templates/products_import_template.csv
@@ -1,6 +1,6 @@
-productNumber,name
-IMP-101,Imported product 101
-IMP-102,Imported product 102
-IMP-103,Imported product 103
-IMP-104,Imported product 104
-IMP-105,Imported product 105
+productNumber,name,stock,gross,net,taxRate,currency,active
+IMP-101,Imported product 101,10,19.99,16.80,19,EUR,true
+IMP-102,Imported product 102,0,29.99,25.20,19,EUR,false
+IMP-103,Imported product 103,5,9.99,8.39,,,true
+IMP-104,Imported product 104,25,49.90,41.93,19,,
+IMP-105,Imported product 105,,,12.61,19,EUR,true

--- a/src/Integration/Infrastructure/Http/Shopware/ShopwareAdminApiClient.php
+++ b/src/Integration/Infrastructure/Http/Shopware/ShopwareAdminApiClient.php
@@ -7,7 +7,7 @@ namespace App\Integration\Infrastructure\Http\Shopware;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class ShopwareAdminApiClient
+final class ShopwareAdminApiClient implements ShopwareAdminApiClientInterface
 {
     public function __construct(
         private readonly HttpClientInterface $httpClient,

--- a/src/Integration/Infrastructure/Http/Shopware/ShopwareAdminApiClientInterface.php
+++ b/src/Integration/Infrastructure/Http/Shopware/ShopwareAdminApiClientInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Infrastructure\Http\Shopware;
+
+interface ShopwareAdminApiClientInterface
+{
+    public function requestOrFail(
+        string $method,
+        string $path,
+        array $json = [],
+        array $query = [],
+        array $headers = [],
+        bool $authenticated = false,
+    ): array;
+}

--- a/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReader.php
+++ b/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReader.php
@@ -17,7 +17,7 @@ final class ProductCsvReader
     public function read(string $file, string $delimiter = ',', ?int $limit = null): array
     {
         if (!is_file($file)) {
-            throw new \InvalidArgumentException(sprintf('CSF file not found: %s', $file));
+            throw new \InvalidArgumentException(sprintf('CSV file not found: %s', $file));
         }
 
         $fh = new \SplFileObject($file, 'r');

--- a/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReader.php
+++ b/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReader.php
@@ -38,20 +38,36 @@ final class ProductCsvReader
             }
 
             if ($header === null) {
-                $header = array_map(static fn($v) => is_string($v) ? trim($v) : '', $row);
+                $header = array_map(static fn ($v) => is_string($v) ? trim($v) : '', $row);
                 continue;
             }
-            
+
             $assoc = $this->combine($header, $row);
 
-            $productNumber = trim($assoc['productNumber'] ?? '');
-            $name = trim((string)$assoc['name'] ?? '');
+            $productNumber = trim((string) ($assoc['productNumber'] ?? ''));
+            $name = trim((string) ($assoc['name'] ?? ''));
 
             if ($productNumber === '' || $name === '') {
                 continue;
             }
 
-            $drafts[] = new ProductDraft($productNumber, $name);
+            $stock = $this->parseInt($assoc['stock'] ?? null);
+            $gross = $this->parseFloat($assoc['gross'] ?? null);
+            $net = $this->parseFloat($assoc['net'] ?? null);
+            $taxRate = $this->parseFloat($assoc['taxRate'] ?? null);
+            $currency = $this->parseString($assoc['currency'] ?? null);
+            $active = $this->parseBool($assoc['active'] ?? null);
+
+            $drafts[] = new ProductDraft(
+                $productNumber,
+                $name,
+                $stock,
+                $gross,
+                $net,
+                $taxRate,
+                $currency,
+                $active,
+            );
 
             if ($limit !== null && count($drafts) >= $limit) {
                 break;
@@ -69,12 +85,75 @@ final class ProductCsvReader
     private function combine(array $header, array $row): array
     {
         $assoc = [];
+
         foreach ($header as $i => $key) {
             if ($key === '') {
                 continue;
             }
+
             $assoc[$key] = $row[$i] ?? null;
         }
+
         return $assoc;
+    }
+
+    private function parseString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+
+    private function parseInt(mixed $value): ?int
+    {
+        $value = $this->parseString($value);
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (!preg_match('/^-?\d+$/', $value)) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    private function parseFloat(mixed $value): ?float
+    {
+        $value = $this->parseString($value);
+
+        if ($value === null) {
+            return null;
+        }
+
+        $normalized = str_replace(',', '.', $value);
+
+        if (!is_numeric($normalized)) {
+            return null;
+        }
+
+        return (float) $normalized;
+    }
+
+    private function parseBool(mixed $value): ?bool
+    {
+        $value = $this->parseString($value);
+
+        if ($value === null) {
+            return null;
+        }
+
+        $normalized = strtolower($value);
+
+        return match ($normalized) {
+            '1', 'true', 'yes', 'y' => true,
+            '0', 'false', 'no', 'n' => false,
+            default => null,
+        };
     }
 }

--- a/src/Integration/Infrastructure/Shopware/Product/ProductDraft.php
+++ b/src/Integration/Infrastructure/Shopware/Product/ProductDraft.php
@@ -9,5 +9,11 @@ final readonly class ProductDraft
     public function __construct(
         public string $productNumber,
         public string $name,
+        public ?int $stock = null,
+        public ?float $gross = null,
+        public ?float $net = null,
+        public ?float $taxRate = null,
+        public ?string $currency = null,
+        public ?bool $active = null,
     ) {}
 }

--- a/src/Integration/Infrastructure/Shopware/Product/ShopwareProductImportService.php
+++ b/src/Integration/Infrastructure/Shopware/Product/ShopwareProductImportService.php
@@ -9,6 +9,10 @@ use App\Integration\Infrastructure\Shopware\ReferenceData\ShopwareReferenceDataR
 
 final class ShopwareProductImportService implements ShopwareProductImporterInterface
 {
+    // TODO: make configurable via services.yaml parameter (app.shopware.default_tax_rate)
+    private const DEFAULT_STOCK = 0;
+    private const DEFAULT_TAX_RATE = 19;
+
     public function __construct(
         private ShopwareAdminApiClient $client,
         private ShopwareReferenceDataResolver $resolver,
@@ -60,44 +64,72 @@ final class ShopwareProductImportService implements ShopwareProductImporterInter
         $existingId = $this->findByProductNumber($draft->productNumber);
 
         if ($existingId === null) {
-            if ($dryRun) {
-                return 'create';
+            if (!$dryRun) {
+                $this->client->requestOrFail(
+                    method: 'POST',
+                    path: '/api/product',
+                    json: $this->buildPayload($draft),
+                    authenticated: true
+                );
             }
-
-            $this->client->requestOrFail(
-                method: 'POST',
-                path: '/api/product',
-                json: [
-                    'name' => $draft->name,
-                    'productNumber' => $draft->productNumber,
-                    'stock' => 10,
-                    'price' => [[
-                        'currencyId' => $this->resolver->getCurrencyId(),
-                        'gross' => 9.99,
-                        'net' => 8.39,
-                        'linked' => false,
-                    ]],
-                    'taxId' => $this->resolver->getTaxId(),
-                ],
-                authenticated: true
-            );
-
             return 'create';
         }
 
-        if ($dryRun) {
-            return 'update';
+        if (!$dryRun) {
+            $this->client->requestOrFail(
+                method: 'PATCH',
+                path: '/api/product/' . $existingId,
+                json: $this->buildPayload($draft),
+                authenticated: true
+            );
         }
 
-        $this->client->requestOrFail(
-            method: 'PATCH',
-            path: '/api/product/'.$existingId,
-            json: [
-                'name' => $draft->name,
-            ],
-            authenticated: true
-        );
-
         return 'update';
+    }
+
+    /**
+     * Builds the Shopware product payload from a ProductDraft.
+     *
+     * Pricing strategy:
+     * - gross is required for a price entry; if missing, no price is sent
+     * - net is computed from gross + taxRate if not explicitly provided
+     * - currency falls back to resolver default (EUR)
+     * - taxRate falls back to DEFAULT_TAX_RATE for net calculation and taxId resolution
+     * - active defaults to true if not set
+     */
+    private function buildPayload(ProductDraft $draft): array
+    {
+        // Use taxRate from draft or fallback to default (e.g. 19%)
+        $effectiveTaxRate = $draft->taxRate ?? self::DEFAULT_TAX_RATE;
+
+        $payload = [
+            'name'          => $draft->name,
+            'productNumber' => $draft->productNumber,
+            'stock'         => $draft->stock ?? self::DEFAULT_STOCK,
+            'active'        => $draft->active ?? true,
+            // Cast to int: taxRate is ?float in ProductDraft, getTaxId() expects int
+            'taxId'         => $this->resolver->getTaxId((int) $effectiveTaxRate),
+        ];
+
+        // Only build price entry if gross is present — Shopware rejects price
+        // entries without a gross value
+        if ($draft->gross !== null) {
+            // Calculate net from gross if not explicitly provided:
+            // net = gross / (1 + taxRate / 100), e.g. 9.99 / 1.19 = 8.3950
+            $net = $draft->net ?? round($draft->gross / (1 + $effectiveTaxRate / 100), 4);
+
+            $payload['price'] = [[
+                // Resolver fetches the UUID for the given currency (e.g. "EUR")
+                // null → resolver uses its own default (EUR)
+                'currencyId' => $this->resolver->getCurrencyId($draft->currency),
+                'gross'      => $draft->gross,
+                'net'        => $net,
+                // linked: false = gross and net are independent values;
+                // linked: true would let Shopware auto-calculate net from gross
+                'linked'     => false,
+            ]];
+        }
+
+        return $payload;
     }
 }

--- a/src/Integration/Infrastructure/Shopware/Product/ShopwareProductImportService.php
+++ b/src/Integration/Infrastructure/Shopware/Product/ShopwareProductImportService.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Integration\Infrastructure\Shopware\Product;
 
-use App\Integration\Infrastructure\Http\Shopware\ShopwareAdminApiClient;
-use App\Integration\Infrastructure\Shopware\ReferenceData\ShopwareReferenceDataResolver;
+use App\Integration\Infrastructure\Http\Shopware\ShopwareAdminApiClientInterface;
+use App\Integration\Infrastructure\Shopware\ReferenceData\ShopwareReferenceDataResolverInterface;
 
 final class ShopwareProductImportService implements ShopwareProductImporterInterface
 {
@@ -14,8 +14,8 @@ final class ShopwareProductImportService implements ShopwareProductImporterInter
     private const DEFAULT_TAX_RATE = 19;
 
     public function __construct(
-        private ShopwareAdminApiClient $client,
-        private ShopwareReferenceDataResolver $resolver,
+        private ShopwareAdminApiClientInterface $client,
+        private ShopwareReferenceDataResolverInterface $resolver,
     ) {}
 
     /**

--- a/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolver.php
+++ b/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolver.php
@@ -8,21 +8,24 @@ use App\Integration\Infrastructure\Http\Shopware\ShopwareAdminApiClient;
 
 final class ShopwareReferenceDataResolver
 {
-    private ?string $currencyId = null;
-    private ?string $taxId = null;
+    // Cache keyed by iso code, e.g. ['EUR' => 'uuid...']
+    private array $currencyIds = [];
+
+    // Cache keyed by tax rate, e.g. [19 => 'uuid...', 7 => 'uuid...']
+    private array $taxIds = [];
 
     public function __construct(
         private readonly ShopwareAdminApiClient $client,
     ) {}
 
-    public function getCurrencyId(?string $currency = null): ?string
+    public function getCurrencyId(?string $currency = null): string
     {
-        if ($this->currencyId !== null) {
-            return $this->currencyId;
-        }
+        // Fall back to EUR if no currency given
+        $isoCode = $currency ?? 'EUR';
 
-        if ($currency === null) {
-            $currency = 'EUR';
+        // Return from cache if already resolved
+        if (isset($this->currencyIds[$isoCode])) {
+            return $this->currencyIds[$isoCode];
         }
 
         $res = $this->client->requestOrFail(
@@ -31,9 +34,9 @@ final class ShopwareReferenceDataResolver
             json: [
                 'limit' => 1,
                 'filter' => [[
-                    'type' => 'equals',
+                    'type'  => 'equals',
                     'field' => 'isoCode',
-                    'value' => $currency,
+                    'value' => $isoCode,
                 ]],
                 'includes' => ['currency' => ['id', 'isoCode']],
             ],
@@ -42,16 +45,17 @@ final class ShopwareReferenceDataResolver
 
         $id = $res['body']['data'][0]['id'] ?? null;
         if (!is_string($id) || $id === '') {
-            throw new \RuntimeException('Could not resolve currencyId for EUR.');
+            throw new \RuntimeException(sprintf('Could not resolve currencyId for "%s".', $isoCode));
         }
 
-        return $this->currencyId = $id;
+        return $this->currencyIds[$isoCode] = $id;
     }
 
-    public function getTaxId(int $taxId = 19): ?string
+    public function getTaxId(int $taxRate = 19): string
     {
-        if ($this->taxId !== null) {
-            return $this->taxId;
+        // Return from cache if already resolved
+        if (isset($this->taxIds[$taxRate])) {
+            return $this->taxIds[$taxRate];
         }
 
         $res = $this->client->requestOrFail(
@@ -60,9 +64,9 @@ final class ShopwareReferenceDataResolver
             json: [
                 'limit' => 1,
                 'filter' => [[
-                    'type' => 'equals',
+                    'type'  => 'equals',
                     'field' => 'taxRate',
-                    'value' => $taxId,
+                    'value' => $taxRate,
                 ]],
                 'includes' => ['tax' => ['id', 'taxRate']],
             ],
@@ -71,9 +75,9 @@ final class ShopwareReferenceDataResolver
 
         $id = $res['body']['data'][0]['id'] ?? null;
         if (!is_string($id) || $id === '') {
-            throw new \RuntimeException('Could not resolve taxId for taxRate=19.');
+            throw new \RuntimeException(sprintf('Could not resolve taxId for taxRate=%d.', $taxRate));
         }
 
-        return $this->taxId = $id;
+        return $this->taxIds[$taxRate] = $id;
     }
 }

--- a/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolver.php
+++ b/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolver.php
@@ -6,7 +6,7 @@ namespace App\Integration\Infrastructure\Shopware\ReferenceData;
 
 use App\Integration\Infrastructure\Http\Shopware\ShopwareAdminApiClient;
 
-final class ShopwareReferenceDataResolver
+final class ShopwareReferenceDataResolver implements ShopwareReferenceDataResolverInterface
 {
     // Cache keyed by iso code, e.g. ['EUR' => 'uuid...']
     private array $currencyIds = [];

--- a/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolverInterface.php
+++ b/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolverInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Infrastructure\Shopware\ReferenceData;
+
+interface ShopwareReferenceDataResolverInterface
+{
+    public function getCurrencyId(?string $currency = null): string;
+    public function getTaxId(int $taxRate = 19): string;
+}

--- a/tests/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReaderTest.php
+++ b/tests/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReaderTest.php
@@ -41,4 +41,76 @@ final class ProductCsvReaderTest extends TestCase
 
         @unlink($tmp);
     }
+
+    public function test_reads_extended_fields_from_csv(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'csv_');
+        self::assertNotFalse($tmp);
+
+        file_put_contents($tmp, implode("\n", [
+            'productNumber,name,stock,gross,net,taxRate,currency,active',
+            'IMP-201,Product 201,10,19.99,16.80,19,EUR,true',
+            'IMP-202,Product 202,0,29.99,25.20,19,EUR,false',
+        ]));
+
+        $reader = new ProductCsvReader();
+        $drafts = $reader->read($tmp);
+
+        self::assertCount(2, $drafts);
+
+        self::assertSame(10, $drafts[0]->stock);
+        self::assertSame(19.99, $drafts[0]->gross);
+        self::assertSame(16.80, $drafts[0]->net);
+        self::assertSame(19.0, $drafts[0]->taxRate);
+        self::assertSame('EUR', $drafts[0]->currency);
+        self::assertTrue($drafts[0]->active);
+
+        self::assertFalse($drafts[1]->active);
+        self::assertSame(0, $drafts[1]->stock);
+
+        @unlink($tmp);
+    }
+
+    public function test_optional_fields_default_to_null(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'csv_');
+        self::assertNotFalse($tmp);
+
+        // taxRate, currency and active are empty
+        file_put_contents($tmp, implode("\n", [
+            'productNumber,name,stock,gross,net,taxRate,currency,active',
+            'IMP-301,Product 301,5,9.99,,,, ',
+        ]));
+
+        $reader = new ProductCsvReader();
+        $drafts = $reader->read($tmp);
+
+        self::assertCount(1, $drafts);
+        self::assertNull($drafts[0]->taxRate);
+        self::assertNull($drafts[0]->currency);
+        self::assertNull($drafts[0]->active);
+
+        @unlink($tmp);
+    }
+
+    public function test_invalid_values_become_null(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'csv_');
+        self::assertNotFalse($tmp);
+
+        file_put_contents($tmp, implode("\n", [
+            'productNumber,name,stock,gross,net,taxRate,currency,active',
+            'IMP-401,Product 401,notanumber,alsonotanumber,,,,maybe',
+        ]));
+
+        $reader = new ProductCsvReader();
+        $drafts = $reader->read($tmp);
+
+        self::assertCount(1, $drafts);
+        self::assertNull($drafts[0]->stock);   // "notanumber" → null
+        self::assertNull($drafts[0]->gross);   // "alsonotanumber" → null
+        self::assertNull($drafts[0]->active);  // "maybe" → null (not in bool map)
+
+        @unlink($tmp);
+    }
 }

--- a/tests/Integration/Infrastructure/Shopware/Product/Import/ShopwareProductImportServiceTest.php
+++ b/tests/Integration/Infrastructure/Shopware/Product/Import/ShopwareProductImportServiceTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Shopware\Product\Import;
+
+use App\Integration\Infrastructure\Http\Shopware\ShopwareAdminApiClientInterface;
+use App\Integration\Infrastructure\Shopware\Product\ProductDraft;
+use App\Integration\Infrastructure\Shopware\Product\ShopwareProductImportService;
+use App\Integration\Infrastructure\Shopware\ReferenceData\ShopwareReferenceDataResolverInterface;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+final class ShopwareProductImportServiceTest extends TestCase
+{
+    private const CURRENCY_ID = 'currency-uuid-eur';
+    private const TAX_ID = 'tax-uuid-19';
+
+    private ShopwareAdminApiClientInterface&MockObject $client;
+    private ShopwareReferenceDataResolverInterface&MockObject $resolver;
+    private ShopwareProductImportService $service;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createMock(ShopwareAdminApiClientInterface::class);
+        $this->resolver = $this->createMock(ShopwareReferenceDataResolverInterface::class);
+
+        $this->resolver->method('getCurrencyId')->willReturn(self::CURRENCY_ID);
+        $this->resolver->method('getTaxId')->willReturn(self::TAX_ID);
+
+        $this->service = new ShopwareProductImportService($this->client, $this->resolver);
+    }
+
+    public function test_upsert_creates_new_product(): void
+    {
+        // findByProductNumber returns null → product does not exist yet
+        $this->client
+            ->method('requestOrFail')
+            ->willReturnCallback(function (string $method, string $path): array {
+                if ($method === 'POST' && str_contains($path, 'search/product')) {
+                    return ['body' => ['data' => []]]; // not found
+                }
+                return ['body' => []]; // create call
+            });
+
+        $draft = new ProductDraft('IMP-NEW', 'New Product', 5, 19.99, null, 19.0, 'EUR', true);
+        $result = $this->service->upsert($draft);
+
+        self::assertSame('create', $result);
+    }
+
+    public function test_upsert_updates_existing_product(): void
+    {
+        $this->client
+            ->method('requestOrFail')
+            ->willReturnCallback(function (string $method, string $path): array {
+                if ($method === 'POST' && str_contains($path, 'search/product')) {
+                    return ['body' => ['data' => [['id' => 'existing-uuid']]]];
+                }
+                return ['body' => []]; // patch call
+            });
+
+        $draft = new ProductDraft('IMP-101', 'Updated Product', 10, 29.99, null, 19.0, 'EUR', true);
+        $result = $this->service->upsert($draft);
+
+        self::assertSame('update', $result);
+    }
+
+    public function test_dry_run_does_not_call_api_for_create(): void
+    {
+        // Override with a real mock here — we need to verify call count
+        $this->client = $this->createMock(ShopwareAdminApiClientInterface::class);
+        $this->client
+            ->expects(self::once())
+            ->method('requestOrFail')
+            ->willReturn(['body' => ['data' => []]]);
+
+        // Rebuild service with the new mock
+        $this->service = new ShopwareProductImportService($this->client, $this->resolver);
+
+        $draft = new ProductDraft('IMP-NEW', 'New Product');
+        $result = $this->service->upsert($draft, dryRun: true);
+
+        self::assertSame('create', $result);
+    }
+
+    public function test_net_is_calculated_from_gross_if_missing(): void
+    {
+        $capturedPayload = null;
+
+        $this->client
+            ->method('requestOrFail')
+            ->willReturnCallback(
+                function (string $method, string $path, array $json) use (&$capturedPayload): array {
+                    if ($method === 'POST' && str_contains($path, 'search/product')) {
+                        return ['body' => ['data' => []]]; // not found → create
+                    }
+                    // This is the create call — capture the payload
+                    $capturedPayload = $json;
+                    return ['body' => []];
+                }
+            );
+
+        // gross=9.99, net=null → net should be calculated as 9.99 / 1.19 = 8.3950
+        $draft = new ProductDraft('IMP-CALC', 'Calc Product', null, 9.99, null, 19.0);
+        $this->service->upsert($draft);
+
+        self::assertNotNull($capturedPayload);
+        self::assertSame(9.99, $capturedPayload['price'][0]['gross']);
+        self::assertSame(round(9.99 / 1.19, 4), $capturedPayload['price'][0]['net']);
+    }
+
+    public function test_active_defaults_to_true_if_null(): void
+    {
+        $capturedPayload = null;
+
+        $this->client
+            ->method('requestOrFail')
+            ->willReturnCallback(
+                function (string $method, string $path, array $json) use (&$capturedPayload): array {
+                    if ($method === 'POST' && str_contains($path, 'search/product')) {
+                        return ['body' => ['data' => []]];
+                    }
+                    $capturedPayload = $json;
+                    return ['body' => []];
+                }
+            );
+
+        // active=null → should default to true in payload
+        $draft = new ProductDraft('IMP-ACTIVE', 'Active Product', null, 9.99, null, 19.0, null, null);
+        $this->service->upsert($draft);
+
+        self::assertTrue($capturedPayload['active']);
+    }
+
+    public function test_no_price_entry_if_gross_is_null(): void
+    {
+        $capturedPayload = null;
+
+        $this->client
+            ->method('requestOrFail')
+            ->willReturnCallback(
+                function (string $method, string $path, array $json) use (&$capturedPayload): array {
+                    if ($method === 'POST' && str_contains($path, 'search/product')) {
+                        return ['body' => ['data' => []]];
+                    }
+                    $capturedPayload = $json;
+                    return ['body' => []];
+                }
+            );
+
+        // gross=null → no price array in payload
+        $draft = new ProductDraft('IMP-NOPRICE', 'No Price Product');
+        $this->service->upsert($draft);
+
+        self::assertArrayNotHasKey('price', $capturedPayload);
+    }
+}


### PR DESCRIPTION
## Summary

Extends the product CSV import pipeline from a minimal 2-column schema
(`productNumber`, `name`) to a realistic import structure including stock,
pricing and active state.

## Changes

**CSV template** (`resources/import/templates/products_import_template.csv`)
- New columns: `stock`, `gross`, `net`, `taxRate`, `currency`, `active`

**`ProductDraft`**
- Extended with all new optional fields (`?int`, `?float`, `?string`, `?bool`)

**`ProductCsvReader`**
- Reads and maps all new columns into `ProductDraft`
- Tolerant parsing: invalid or empty values become `null` (no exceptions yet)
- Private helpers: `parseString()`, `parseInt()`, `parseFloat()`, `parseBool()`

**`ShopwareProductImportService`**
- New `buildPayload()` helper unifies create and update payload building
- Maps `stock`, `gross`, `net`, `taxRate`, `currency`, `active` from `ProductDraft`
- Computes `net` from `gross` + `taxRate` if not explicitly provided
- Price entry omitted if `gross` is null
- Fallback defaults: `stock=0`, `taxRate=19`, `active=true`

**`ShopwareReferenceDataResolver`**
- Fixed single-value cache bug: cache is now keyed by iso code / tax rate
- Handles multiple currencies and tax rates correctly within one batch

**Interfaces introduced**
- `ShopwareAdminApiClientInterface`
- `ShopwareReferenceDataResolverInterface`

Required to allow PHPUnit mocking of `final` classes.

**Tests**
- Extended `ProductCsvReaderTest` with new field parsing, null defaults and
  invalid value handling
- New `ShopwareProductImportServiceTest` covering upsert, dry-run, payload
  building, net calculation and active default

**Docs**
- README updated with CSV format, defaults table, import commands and roadmap

## Closes

Closes #23