### PR TITLE
M1/7 csv import validation and error reporting

### DIFF
--- a/resources/import/templates/products_import_template.csv
+++ b/resources/import/templates/products_import_template.csv
@@ -5,3 +5,6 @@ IMP-103,Imported product 103,5,9.99,,,,true
 IMP-104,Imported product 104,25,49.90,,19,,
 IMP-105,Imported product 105,8,24.99,,19,EUR,true
 IMP-106,Imported product 106,15,15.99,,7,EUR,true
+IMP-107,Imported product 107,-5,19.99,,19,EUR,true
+IMP-108,Imported product 108,,8.39,19,EUR,true
+IMP-109,Imported product 109,10,19.99,,-3,EUR,true

--- a/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvImportRunner.php
+++ b/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvImportRunner.php
@@ -10,6 +10,7 @@ final class ProductCsvImportRunner
 {
     public function __construct(
         private readonly ShopwareProductImporterInterface $importService,
+        private readonly ProductDraftValidatorInterface $validator,
     ) {}
 
     /**
@@ -30,29 +31,45 @@ final class ProductCsvImportRunner
         $failed = 0;
         $results = [];
 
+        $rowNumber = 2; // row 1 is the header, already consumed by the reader
         foreach ($drafts as $draft) {
-            try {
-                $action = $this->importService->upsert($draft, $dryRun);
+            $errors = $this->validator->validate($draft, $rowNumber);
 
-                match ($action) {
-                    'create' => $created++,
-                    'update' => $updated++,
-                    default  => null,
-                };
+            if (count($errors) === 0) {
+                try {
+                    $action = $this->importService->upsert($draft, $dryRun);
 
-                $results[] = [
-                    'productNumber' => $draft->productNumber,
-                    'name' => $draft->name,
-                    'action' => $action,
-                ];
-            } catch (\Throwable $e) {
+                    match ($action) {
+                        'create' => $created++,
+                        'update' => $updated++,
+                        default => null,
+                    };
+
+                    $results[] = [
+                        'productNumber' => $draft->productNumber,
+                        'name' => $draft->name,
+                        'action' => $action,
+                    ];
+                } catch (\Throwable $e) {
+                    $failed++;
+                    $results[] = [
+                        'productNumber' => $draft->productNumber,
+                        'name' => $draft->name,
+                        'action' => 'error: ' . $e->getMessage(),
+                    ];
+                }
+            } else {
                 $failed++;
-                $results[] = [
-                    'productNumber' => $draft->productNumber,
-                    'name' => $draft->name,
-                    'action' => 'error: ' . $e->getMessage(),
-                ];
+                foreach ($errors as $error) {
+                    $results[] = [
+                        'productNumber' => $draft->productNumber,
+                        'name'          => $draft->name,
+                        'action'        => 'validation: ' . $error->field . ' – ' . $error->reason,
+                    ];
+                }
             }
+
+            $rowNumber++;
         }
 
         return [

--- a/src/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidator.php
+++ b/src/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidator.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Infrastructure\Shopware\Product\Import;
+
+use App\Integration\Infrastructure\Shopware\Product\ProductDraft;
+
+final class ProductDraftValidator implements ProductDraftValidatorInterface
+{
+    /**
+     * Validates a single ProductDraft and returns all validation errors.
+     * Returns an empty array if the draft is valid.
+     *
+     * @return list<ValidationError>
+     */
+    public function validate(ProductDraft $draft, int $rowNumber): array
+    {
+        $errors = [];
+
+        // productNumber and name are already enforced in the reader (empty rows
+        // are skipped), but we guard here as well for direct API usage
+        if ($draft->productNumber === '') {
+            $errors[] = new ValidationError($rowNumber, null, 'productNumber', 'required');
+        }
+
+        if ($draft->name === '') {
+            $errors[] = new ValidationError($rowNumber, $draft->productNumber, 'name', 'required');
+        }
+
+        // stock must be non-negative if provided
+        if ($draft->stock !== null && $draft->stock < 0) {
+            $errors[] = new ValidationError(
+                $rowNumber,
+                $draft->productNumber,
+                'stock',
+                'must be non-negative integer'
+            );
+        }
+
+        // gross is required for a price entry — a row without gross will import
+        // without any price, which is likely unintentional
+        if ($draft->gross === null && $draft->net !== null) {
+            $errors[] = new ValidationError(
+                $rowNumber,
+                $draft->productNumber,
+                'gross',
+                'required when net is provided'
+            );
+        }
+
+        // taxRate must be positive if provided
+        if ($draft->taxRate !== null && $draft->taxRate <= 0) {
+            $errors[] = new ValidationError(
+                $rowNumber,
+                $draft->productNumber,
+                'taxRate',
+                'must be a positive number'
+            );
+        }
+
+        return $errors;
+    }
+}

--- a/src/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidatorInterface.php
+++ b/src/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidatorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Infrastructure\Shopware\Product\Import;
+
+use App\Integration\Infrastructure\Shopware\Product\ProductDraft;
+
+interface ProductDraftValidatorInterface
+{
+    /**
+     * @return list<ValidationError>
+     */
+    public function validate(ProductDraft $draft, int $rowNumber): array;
+}

--- a/src/Integration/Infrastructure/Shopware/Product/Import/ValidationError.php
+++ b/src/Integration/Infrastructure/Shopware/Product/Import/ValidationError.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Infrastructure\Shopware\Product\Import;
+
+final readonly class ValidationError
+{
+    public function __construct(
+        // CSV row number (header = 1, first data row = 2)
+        public int $rowNumber,
+        // productNumber from the row, or null if it could not be read
+        public ?string $productNumber,
+        // which field caused the error, e.g. "gross"
+        public string $field,
+        // human-readable reason, e.g. "required for price entry"
+        public string $reason,
+    ) {}
+
+    public function toString(): string
+    {
+        $identifier = $this->productNumber ?? 'unknown';
+
+        return sprintf(
+            'Row %d [%s] - %s: %s',
+            $this->rowNumber,
+            $identifier,
+            $this->field,
+            $this->reason
+        );
+    }
+}

--- a/tests/Integration/Infrastructure/Shopware/Product/Import/ProductCsvImportRunnerTest.php
+++ b/tests/Integration/Infrastructure/Shopware/Product/Import/ProductCsvImportRunnerTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Infrastructure\Shopware\Product\Import;
 
 use App\Integration\Infrastructure\Shopware\Product\Import\ProductCsvImportRunner;
+use App\Integration\Infrastructure\Shopware\Product\Import\ProductDraftValidator;
+use App\Integration\Infrastructure\Shopware\Product\Import\ProductDraftValidatorInterface;
+use App\Integration\Infrastructure\Shopware\Product\Import\ValidationError;
 use App\Integration\Infrastructure\Shopware\Product\ProductDraft;
 use App\Integration\Infrastructure\Shopware\Product\ShopwareProductImporterInterface;
 use PHPUnit\Framework\TestCase;
@@ -20,7 +23,7 @@ final class ProductCsvImportRunnerTest extends TestCase
             ->method('upsert')
             ->willReturnOnConsecutiveCalls('create', 'update');
 
-        $runner = new ProductCsvImportRunner($service);
+        $runner = new ProductCsvImportRunner($service, new ProductDraftValidator());
 
         $drafts = [
             new ProductDraft('IMP-401', 'Imported product 401'),
@@ -59,7 +62,7 @@ final class ProductCsvImportRunnerTest extends TestCase
                 }
             );
 
-        $runner = new ProductCsvImportRunner($service);
+        $runner = new ProductCsvImportRunner($service, new ProductDraftValidator());
 
         $drafts = [
             new ProductDraft('IMP-501', 'Imported product 501'),
@@ -76,5 +79,52 @@ final class ProductCsvImportRunnerTest extends TestCase
 
         self::assertStringStartsWith('error:', $summary['results'][0]['action']);
         self::assertSame('create', $summary['results'][1]['action']);
+    }
+
+    public function test_validation_errors_are_counted_as_failed(): void
+    {
+        $service = $this->createStub(ShopwareProductImporterInterface::class);
+        $validator = $this->createStub(ProductDraftValidatorInterface::class);
+
+        // First draft fails validation, second passes
+        $validator
+            ->method('validate')
+            ->willReturnOnConsecutiveCalls(
+                [new ValidationError(2, 'IMP-601', 'gross', 'required when net is provided')],
+                [],
+            );
+
+        $service->method('upsert')->willReturn('create');
+
+        $runner = new ProductCsvImportRunner($service, $validator);
+
+        $drafts = [
+            new ProductDraft('IMP-601', 'Product 601', null, null, 8.39),
+            new ProductDraft('IMP-602', 'Product 602', 5, 9.99),
+        ];
+
+        $summary = $runner->importDrafts($drafts);
+
+        self::assertSame(2, $summary['total']);
+        self::assertSame(1, $summary['created']);
+        self::assertSame(0, $summary['updated']);
+        self::assertSame(1, $summary['failed']);
+    }
+
+    public function test_validation_error_appears_in_results(): void
+    {
+        $service = $this->createStub(ShopwareProductImporterInterface::class);
+        $validator = $this->createStub(ProductDraftValidatorInterface::class);
+
+        $validator
+            ->method('validate')
+            ->willReturn([new ValidationError(2, 'IMP-701', 'gross', 'required when net is provided')]);
+
+        $runner = new ProductCsvImportRunner($service, $validator);
+
+        $drafts = [new ProductDraft('IMP-701', 'Product 701', null, null, 8.39)];
+        $summary = $runner->importDrafts($drafts);
+
+        self::assertStringStartsWith('validation:', $summary['results'][0]['action']);
     }
 }

--- a/tests/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidatorTest.php
+++ b/tests/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidatorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Shopware\Product\Import;
+
+use App\Integration\Infrastructure\Shopware\Product\Import\ProductDraftValidator;
+use App\Integration\Infrastructure\Shopware\Product\ProductDraft;
+use PHPUnit\Framework\TestCase;
+
+final class ProductDraftValidatorTest extends TestCase
+{
+    private ProductDraftValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new ProductDraftValidator();
+    }
+
+    public function test_valid_draft_returns_no_errors(): void
+    {
+        $draft = new ProductDraft('IMP-101', 'Product 101', 10, 19.99, null, 19.0, 'EUR', true);
+        $errors = $this->validator->validate($draft, 2);
+
+        self::assertCount(0, $errors);
+    }
+
+    public function test_negative_stock_returns_error(): void
+    {
+        $draft = new ProductDraft('IMP-101', 'Product 101', -1, 19.99);
+        $errors = $this->validator->validate($draft, 2);
+
+        self::assertCount(1, $errors);
+        self::assertSame('stock', $errors[0]->field);
+        self::assertSame(2, $errors[0]->rowNumber);
+        self::assertSame('IMP-101', $errors[0]->productNumber);
+    }
+
+    public function test_net_without_gross_returns_error(): void
+    {
+        // net provided but gross is null → price entry would be incomplete
+        $draft = new ProductDraft('IMP-102', 'Product 102', null, null, 8.39);
+        $errors = $this->validator->validate($draft, 3);
+
+        self::assertCount(1, $errors);
+        self::assertSame('gross', $errors[0]->field);
+        self::assertSame(3, $errors[0]->rowNumber);
+    }
+
+    public function test_zero_tax_rate_returns_error(): void
+    {
+        $draft = new ProductDraft('IMP-103', 'Product 103', null, 9.99, null, 0.0);
+        $errors = $this->validator->validate($draft, 4);
+
+        self::assertCount(1, $errors);
+        self::assertSame('taxRate', $errors[0]->field);
+    }
+
+    public function test_negative_tax_rate_returns_error(): void
+    {
+        $draft = new ProductDraft('IMP-104', 'Product 104', null, 9.99, null, -7.0);
+        $errors = $this->validator->validate($draft, 5);
+
+        self::assertCount(1, $errors);
+        self::assertSame('taxRate', $errors[0]->field);
+    }
+
+    public function test_multiple_errors_are_collected(): void
+    {
+        // negative stock AND net without gross → two errors at once
+        $draft = new ProductDraft('IMP-105', 'Product 105', -5, null, 8.39);
+        $errors = $this->validator->validate($draft, 6);
+
+        self::assertCount(2, $errors);
+
+        $fields = array_map(fn($e) => $e->field, $errors);
+        self::assertContains('stock', $fields);
+        self::assertContains('gross', $fields);
+    }
+
+    public function test_null_optional_fields_are_valid(): void
+    {
+        // stock, gross, taxRate all null → valid, just no price entry
+        $draft = new ProductDraft('IMP-106', 'Product 106');
+        $errors = $this->validator->validate($draft, 7);
+
+        self::assertCount(0, $errors);
+    }
+
+    public function test_error_to_string_format(): void
+    {
+        $draft = new ProductDraft('IMP-107', 'Product 107', -1);
+        $errors = $this->validator->validate($draft, 2);
+
+        self::assertCount(1, $errors);
+        self::assertSame(
+            'Row 2 [IMP-107] - stock: must be non-negative integer',
+            $errors[0]->toString()
+        );
+    }
+}

--- a/tests/Integration/Infrastructure/Shopware/Product/Import/ShopwareProductImportServiceTest.php
+++ b/tests/Integration/Infrastructure/Shopware/Product/Import/ShopwareProductImportServiceTest.php
@@ -9,21 +9,21 @@ use App\Integration\Infrastructure\Shopware\Product\ProductDraft;
 use App\Integration\Infrastructure\Shopware\Product\ShopwareProductImportService;
 use App\Integration\Infrastructure\Shopware\ReferenceData\ShopwareReferenceDataResolverInterface;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 
 final class ShopwareProductImportServiceTest extends TestCase
 {
     private const CURRENCY_ID = 'currency-uuid-eur';
     private const TAX_ID = 'tax-uuid-19';
 
-    private ShopwareAdminApiClientInterface&MockObject $client;
-    private ShopwareReferenceDataResolverInterface&MockObject $resolver;
+    private ShopwareAdminApiClientInterface&Stub $client;
+    private ShopwareReferenceDataResolverInterface&Stub $resolver;
     private ShopwareProductImportService $service;
 
     protected function setUp(): void
     {
-        $this->client = $this->createMock(ShopwareAdminApiClientInterface::class);
-        $this->resolver = $this->createMock(ShopwareReferenceDataResolverInterface::class);
+        $this->client = $this->createStub(ShopwareAdminApiClientInterface::class);
+        $this->resolver = $this->createStub(ShopwareReferenceDataResolverInterface::class);
 
         $this->resolver->method('getCurrencyId')->willReturn(self::CURRENCY_ID);
         $this->resolver->method('getTaxId')->willReturn(self::TAX_ID);


### PR DESCRIPTION
## Summary

Adds a validation layer to the CSV import pipeline that catches invalid rows
before they reach the Shopware API. Invalid rows are reported clearly in the
import summary while valid rows in the same file continue to import normally.

## Changes

**`ValidationError`** (new)
- DTO carrying rowNumber, productNumber, field and reason
- `toString()` for readable CLI output

**`ProductDraftValidator`** (new)
- Validates a single `ProductDraft` and returns all errors — no early abort
- Rules: stock non-negative, gross required when net is provided, taxRate positive

**`ProductDraftValidatorInterface`** (new)
- Required for PHPUnit mocking of the `final` validator class

**`ProductCsvImportRunner`**
- Validator injected via constructor
- Invalid rows are skipped, counted as `failed` and appear in results with
  `validation: field – reason` message
- Row numbering starts at 2 (row 1 = header)

**Tests**
- `ProductDraftValidatorTest` covering all validation rules including
  multiple errors per row and `toString()` format
- `ProductCsvImportRunnerTest` extended with validation error cases
- `ShopwareProductImportServiceTest` fixed: `Stub` intersection type for
  PHPStan compatibility

## Tested
```
validation: stock – must be non-negative integer: IMP-107
validation: gross – required when net is provided: IMP-108
validation: taxRate – must be a positive number: IMP-109
Summary: created=0, updated=6, failed=3 (dry-run)
```

## Closes

Closes #25