### PR TITLE
M2.0 – Add Application layer with ImportProductsUseCase

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -37,6 +37,8 @@ services:
             $clientId: '%env(resolve:SHOPWARE_CLIENT_ID)%'
             $clientSecret: '%env(resolve:SHOPWARE_CLIENT_SECRET)%'
 
+    App\Integration\Application\Port\ProductReaderInterface: '@App\Integration\Infrastructure\Shopware\Product\Import\ProductCsvReader'
+    App\Integration\Application\Port\ProductImporterInterface: '@App\Integration\Infrastructure\Shopware\Product\Import\ProductCsvImportRunner'
     App\Integration\Infrastructure\Http\Shopware\ShopwareAdminApiClientInterface: '@App\Integration\Infrastructure\Http\Shopware\ShopwareAdminApiClient'
     App\Integration\Infrastructure\Http\Shopware\ShopwareTokenProviderInterface: '@App\Integration\Infrastructure\Http\Shopware\ShopwareTokenProvider'
     App\Integration\Infrastructure\Shopware\Product\ShopwareProductImportInterface: '@App\Integration\Infrastructure\Shopware\Product\ShopwareProductImportService'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -37,6 +37,7 @@ services:
             $clientId: '%env(resolve:SHOPWARE_CLIENT_ID)%'
             $clientSecret: '%env(resolve:SHOPWARE_CLIENT_SECRET)%'
 
+    App\Integration\Application\ImportProductsUseCaseInterface: '@App\Integration\Application\ImportProductsUseCase'
     App\Integration\Application\Port\ProductReaderInterface: '@App\Integration\Infrastructure\Shopware\Product\Import\ProductCsvReader'
     App\Integration\Application\Port\ProductImporterInterface: '@App\Integration\Infrastructure\Shopware\Product\Import\ProductCsvImportRunner'
     App\Integration\Infrastructure\Http\Shopware\ShopwareAdminApiClientInterface: '@App\Integration\Infrastructure\Http\Shopware\ShopwareAdminApiClient'

--- a/src/Command/Integration/ShopwareProductsImportBatchCommand.php
+++ b/src/Command/Integration/ShopwareProductsImportBatchCommand.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Command\Integration;
 
-use App\Integration\Infrastructure\Shopware\Product\Import\ProductCsvImportRunnerInterface;
-use App\Integration\Infrastructure\Shopware\Product\Import\ProductCsvReaderInterface;
+use App\Integration\Application\ImportProductsUseCaseInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,8 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class ShopwareProductsImportBatchCommand extends Command
 {
     public function __construct(
-        private readonly ProductCsvReaderInterface $csvReader,
-        private readonly ProductCsvImportRunnerInterface $runner,
+        private readonly ImportProductsUseCaseInterface $useCase,
     ) {
         parent::__construct();
     }
@@ -56,7 +54,6 @@ final class ShopwareProductsImportBatchCommand extends Command
             return Command::FAILURE;
         }
 
-        // Ensure archive dirs exist
         if (!$this->ensureDir($processedDir) || !$this->ensureDir($failedDir)) {
             $output->writeln('<error>Could not create processed/failed directories.</error>');
             return Command::FAILURE;
@@ -88,28 +85,20 @@ final class ShopwareProductsImportBatchCommand extends Command
             $output->writeln('File: '.$basename);
 
             try {
-                $drafts = $this->csvReader->read($file, $delimiter, $limit);
-                $summary = $this->runner->importDrafts($drafts, $dryRun);
+                $result = $this->useCase->execute($file, $delimiter, $limit, $dryRun);
 
-                foreach ($summary['results'] as $r) {
+                foreach ($result->results as $r) {
                     $output->writeln(sprintf('%s: %s | %s', $r['action'], $r['productNumber'], $r['name']));
                 }
 
-                $output->writeln(sprintf(
-                    'Summary: created=%d, updated=%d, skipped=%d, failed=%d%s',
-                    $summary['created'],
-                    $summary['updated'],
-                    $summary['skipped'],
-                    $summary['failed'],
-                    $dryRun ? ' (dry-run)' : ''
-                ));
+                $output->writeln($result->summary());
 
                 if ($dryRun) {
                     continue;
                 }
 
-                $targetDir = ($summary['failed'] > 0) ? $failedDir : $processedDir;
-                if ($summary['failed'] > 0) {
+                $targetDir = $result->hasFailures() ? $failedDir : $processedDir;
+                if ($result->hasFailures()) {
                     $overallFailedFiles++;
                 }
 
@@ -123,7 +112,6 @@ final class ShopwareProductsImportBatchCommand extends Command
                 }
             } catch (\Throwable $e) {
                 $overallFailedFiles++;
-
                 $output->writeln('<error>File failed: '.$e->getMessage().'</error>');
 
                 if (!$dryRun) {

--- a/src/Command/Integration/ShopwareProductsImportCsvCommand.php
+++ b/src/Command/Integration/ShopwareProductsImportCsvCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Command\Integration;
 
-use App\Integration\Application\ImportProductsUseCase;
+use App\Integration\Application\ImportProductsUseCaseInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class ShopwareProductsImportCsvCommand extends Command
 {
     public function __construct(
-        private readonly ImportProductsUseCase $useCase,
+        private readonly ImportProductsUseCaseInterface $useCase,
     ) {
         parent::__construct();
     }

--- a/src/Command/Integration/ShopwareProductsImportCsvCommand.php
+++ b/src/Command/Integration/ShopwareProductsImportCsvCommand.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Command\Integration;
 
-use App\Integration\Infrastructure\Shopware\Product\Import\ProductCsvImportRunnerInterface;
-use App\Integration\Infrastructure\Shopware\Product\Import\ProductCsvReaderInterface;
+use App\Integration\Application\ImportProductsUseCase;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,8 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class ShopwareProductsImportCsvCommand extends Command
 {
     public function __construct(
-        private readonly ProductCsvReaderInterface $csvReader,
-        private readonly ProductCsvImportRunnerInterface $runner,
+        private readonly ImportProductsUseCase $useCase,
     ) {
         parent::__construct();
     }
@@ -48,7 +46,7 @@ final class ShopwareProductsImportCsvCommand extends Command
         $limit = $limitOpt === null ? null : (int) $limitOpt;
 
         try {
-            $drafts = $this->csvReader->read($file, $delimiter, $limit);
+            $result = $this->useCase->execute($file, $delimiter, $limit, $dryRun);
         } catch (\Throwable $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             return Command::FAILURE;
@@ -56,36 +54,21 @@ final class ShopwareProductsImportCsvCommand extends Command
 
         $output->writeln(sprintf(
             'Importing %d products from CSV%s',
-            count($drafts),
+            $result->total,
             $dryRun ? ' (dry-run)' : ''
         ));
 
-        if ($drafts === []) {
+        if ($result->total === 0) {
             $output->writeln('<comment>No valid rows found.</comment>');
             return Command::SUCCESS;
         }
 
-        $summary = $this->runner->importDrafts($drafts, $dryRun);
-
-        $output->writeln(sprintf(
-            'Importing %d products from CSV%s',
-            $summary['total'],
-            $dryRun ? ' (dry-run)' : ''
-        ));
-
-        foreach ($summary['results'] as $r) {
+        foreach ($result->results as $r) {
             $output->writeln(sprintf('%s: %s | %s', $r['action'], $r['productNumber'], $r['name']));
         }
 
-        $output->writeln(sprintf(
-            'Summary: created=%d, updated=%d, skipped=%d, failed=%d%s',
-            $summary['created'],
-            $summary['updated'],
-            $summary['skipped'],
-            $summary['failed'],
-            $dryRun ? ' (dry-run)' : ''
-        ));
+        $output->writeln($result->summary());
 
-        return $summary['failed'] > 0 ? Command::FAILURE : Command::SUCCESS;
+        return $result->hasFailures() ? Command::FAILURE : Command::SUCCESS;
     }
 }

--- a/src/Integration/Application/ImportProductsUseCase.php
+++ b/src/Integration/Application/ImportProductsUseCase.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Application;
+
+use App\Integration\Application\Port\ProductImporterInterface;
+use App\Integration\Application\Port\ProductReaderInterface;
+use App\Integration\Domain\ImportResult;
+
+final class ImportProductsUseCase
+{
+    public function __construct(
+        private readonly ProductReaderInterface $reader,
+        private readonly ProductImporterInterface $importer,
+    ) {}
+
+    /**
+     * Reads products from a source and imports them.
+     * Returns an ImportResult with counts and per-row details.
+     */
+    public function execute(
+        string $source,
+        string $delimiter = ',',
+        ?int $limit = null,
+        bool $dryRun = false,
+    ): ImportResult {
+        $drafts = $this->reader->read($source, $delimiter, $limit);
+
+        if ($drafts === []) {
+            return new ImportResult(
+                total: 0,
+                created: 0,
+                updated: 0,
+                skipped: 0,
+                failed: 0,
+                results: [],
+                dryRun: $dryRun,
+            );
+        }
+
+        return $this->importer->import($drafts, $dryRun);
+    }
+}

--- a/src/Integration/Application/ImportProductsUseCase.php
+++ b/src/Integration/Application/ImportProductsUseCase.php
@@ -8,7 +8,7 @@ use App\Integration\Application\Port\ProductImporterInterface;
 use App\Integration\Application\Port\ProductReaderInterface;
 use App\Integration\Domain\ImportResult;
 
-final class ImportProductsUseCase
+final class ImportProductsUseCase implements ImportProductsUseCaseInterface
 {
     public function __construct(
         private readonly ProductReaderInterface $reader,

--- a/src/Integration/Application/ImportProductsUseCaseInterface.php
+++ b/src/Integration/Application/ImportProductsUseCaseInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Application;
+
+use App\Integration\Domain\ImportResult;
+
+interface ImportProductsUseCaseInterface
+{
+    public function execute(
+        string $source,
+        string $delimiter = ',',
+        ?int $limit = null,
+        bool $dryRun = false,
+    ): ImportResult;
+}

--- a/src/Integration/Application/Port/ProductImporterInterface.php
+++ b/src/Integration/Application/Port/ProductImporterInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Application\Port;
+
+use App\Integration\Domain\ImportResult;
+use App\Integration\Domain\ProductDraft;
+
+interface ProductImporterInterface
+{
+    /**
+     * Imports a list of product drafts and returns the result.
+     *
+     * @param list<ProductDraft> $drafts
+     */
+    public function import(array $drafts, bool $dryRun = false): ImportResult;
+}

--- a/src/Integration/Application/Port/ProductReaderInterface.php
+++ b/src/Integration/Application/Port/ProductReaderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Application\Port;
+
+use App\Integration\Domain\ProductDraft;
+
+interface ProductReaderInterface
+{
+    /**
+     * Reads product data from a source and returns a list of drafts.
+     *
+     * @return list<ProductDraft>
+     */
+    public function read(string $source, string $delimiter = ',', ?int $limit = null): array;
+}

--- a/src/Integration/Domain/ImportResult.php
+++ b/src/Integration/Domain/ImportResult.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Domain;
+
+final readonly class ImportResult
+{
+    /**
+     * @param list<array{productNumber: string, name: string, action: string}> $results
+     */
+    public function __construct(
+        public int $total,
+        public int $created,
+        public int $updated,
+        public int $skipped,
+        public int $failed,
+        public array $results,
+        public bool $dryRun = false,
+    ) {
+    }
+
+    public function hasFailures(): bool
+    {
+        return $this->failed > 0;
+    }
+
+    public function summary(): string
+    {
+        return sprintf(
+            'Summary: created=%d, updated=%d, skipped=%d, failed=%d%s',
+            $this->created,
+            $this->updated,
+            $this->skipped,
+            $this->failed,
+            $this->dryRun ? ' (dry-run)' : '',
+        );
+    }
+}

--- a/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvImportRunner.php
+++ b/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvImportRunner.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Integration\Infrastructure\Shopware\Product\Import;
 
+use App\Integration\Application\Port\ProductImporterInterface;
+use App\Integration\Domain\ImportResult;
 use App\Integration\Domain\ProductDraft;
 use App\Integration\Infrastructure\Shopware\Product\ShopwareProductImportInterface;
 
-final class ProductCsvImportRunner implements ProductCsvImportRunnerInterface
+final class ProductCsvImportRunner implements ProductCsvImportRunnerInterface, ProductImporterInterface
 {
     public function __construct(
         private readonly ShopwareProductImportInterface $importService,
@@ -15,8 +17,27 @@ final class ProductCsvImportRunner implements ProductCsvImportRunnerInterface
     ) {}
 
     /**
+     * Implements ProductImporterInterface — returns typed ImportResult.
+     *
      * @param list<ProductDraft> $drafts
-     * @param bool $dryRun
+     */
+    public function import(array $drafts, bool $dryRun = false): ImportResult
+    {
+        $raw = $this->importDrafts($drafts, $dryRun);
+
+        return new ImportResult(
+            total:   $raw['total'],
+            created: $raw['created'],
+            updated: $raw['updated'],
+            skipped: $raw['skipped'],
+            failed:  $raw['failed'],
+            results: $raw['results'],
+            dryRun:  $dryRun,
+        );
+    }
+
+    /**
+     * @param list<ProductDraft> $drafts
      * @return array{
      *   total:int,
      *   created:int,

--- a/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReader.php
+++ b/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReader.php
@@ -4,9 +4,10 @@ declare(strict_types = 1);
 
 namespace App\Integration\Infrastructure\Shopware\Product\Import;
 
+use App\Integration\Application\Port\ProductReaderInterface;
 use App\Integration\Domain\ProductDraft;
 
-final class ProductCsvReader implements ProductCsvReaderInterface
+final class ProductCsvReader implements ProductCsvReaderInterface, ProductReaderInterface
 {
     /**
      * @param string $file

--- a/tests/Integration/Infrastructure/Command/ShopwareProductsImportBatchCommandTest.php
+++ b/tests/Integration/Infrastructure/Command/ShopwareProductsImportBatchCommandTest.php
@@ -5,20 +5,17 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Infrastructure\Command;
 
 use App\Command\Integration\ShopwareProductsImportBatchCommand;
-use App\Integration\Domain\ProductDraft;
-use App\Integration\Infrastructure\Shopware\Product\Import\ProductCsvImportRunnerInterface;
-use App\Integration\Infrastructure\Shopware\Product\Import\ProductCsvReaderInterface;
+use App\Integration\Application\ImportProductsUseCaseInterface;
+use App\Integration\Domain\ImportResult;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 final class ShopwareProductsImportBatchCommandTest extends TestCase
 {
-    private function makeTester(
-        ProductCsvReaderInterface $csvReader,
-        ProductCsvImportRunnerInterface $runner,
-    ): CommandTester {
+    private function makeTester(ImportProductsUseCaseInterface $useCase): CommandTester
+    {
         return new CommandTester(
-            new ShopwareProductsImportBatchCommand($csvReader, $runner)
+            new ShopwareProductsImportBatchCommand($useCase)
         );
     }
 
@@ -29,21 +26,18 @@ final class ShopwareProductsImportBatchCommandTest extends TestCase
         $csvFile = $tmpDir . '/products.csv';
         file_put_contents($csvFile, "productNumber,name\nP-001,Test Product\n");
 
-        $draft = new ProductDraft('P-001', 'Test Product');
+        $result = new ImportResult(
+            total: 1, created: 1, updated: 0, skipped: 0, failed: 0,
+            results: [['productNumber' => 'P-001', 'name' => 'Test Product', 'action' => 'create']],
+        );
 
-        $csvReader = $this->createStub(ProductCsvReaderInterface::class);
-        $csvReader->method('read')->willReturn([$draft]);
-
-        $runner = $this->createStub(ProductCsvImportRunnerInterface::class);
-        $runner->method('importDrafts')->willReturn([
-            'total' => 1, 'created' => 1, 'updated' => 0, 'skipped' => 0, 'failed' => 0,
-            'results' => [['productNumber' => 'P-001', 'name' => 'Test Product', 'action' => 'create']],
-        ]);
+        $useCase = $this->createStub(ImportProductsUseCaseInterface::class);
+        $useCase->method('execute')->willReturn($result);
 
         $processedDir = $tmpDir . '/processed';
         $failedDir = $tmpDir . '/failed';
 
-        $tester = $this->makeTester($csvReader, $runner);
+        $tester = $this->makeTester($useCase);
         $tester->execute([
             '--dir' => $tmpDir,
             '--pattern' => 'products.csv',
@@ -62,30 +56,33 @@ final class ShopwareProductsImportBatchCommandTest extends TestCase
         @rmdir($tmpDir);
     }
 
-    public function test_dry_run_calls_importDrafts_with_dryRun_true(): void
+    public function test_dry_run_does_not_move_files(): void
     {
         $tmpDir = sys_get_temp_dir() . '/batch_dryrun_' . uniqid();
         mkdir($tmpDir);
         $csvFile = $tmpDir . '/products.csv';
         file_put_contents($csvFile, "productNumber,name\nP-001,Test Product\n");
 
-        $draft = new ProductDraft('P-001', 'Test Product');
+        $result = new ImportResult(
+            total: 1, created: 0, updated: 0, skipped: 1, failed: 0,
+            results: [['productNumber' => 'P-001', 'name' => 'Test Product', 'action' => 'skipped']],
+            dryRun: true,
+        );
 
-        $csvReader = $this->createStub(ProductCsvReaderInterface::class);
-        $csvReader->method('read')->willReturn([$draft]);
-
-        // Use createMock here — we need to assert $dryRun=true is passed
-        $runner = $this->createMock(ProductCsvImportRunnerInterface::class);
-        $runner
+        // createMock — we verify dryRun=true is passed to execute()
+        $useCase = $this->createMock(ImportProductsUseCaseInterface::class);
+        $useCase
             ->expects(self::once())
-            ->method('importDrafts')
-            ->with([$draft], true)
-            ->willReturn([
-                'total' => 1, 'created' => 0, 'updated' => 0, 'skipped' => 1, 'failed' => 0,
-                'results' => [['productNumber' => 'P-001', 'name' => 'Test Product', 'action' => 'skipped']],
-            ]);
+            ->method('execute')
+            ->with(
+                self::stringEndsWith('products.csv'),
+                ',',
+                null,
+                true, // dryRun must be true
+            )
+            ->willReturn($result);
 
-        $tester = $this->makeTester($csvReader, $runner);
+        $tester = $this->makeTester($useCase);
         $tester->execute([
             '--dir' => $tmpDir,
             '--pattern' => 'products.csv',
@@ -108,10 +105,7 @@ final class ShopwareProductsImportBatchCommandTest extends TestCase
         $tmpDir = sys_get_temp_dir() . '/batch_empty_' . uniqid();
         mkdir($tmpDir);
 
-        $tester = $this->makeTester(
-            $this->createStub(ProductCsvReaderInterface::class),
-            $this->createStub(ProductCsvImportRunnerInterface::class),
-        );
+        $tester = $this->makeTester($this->createStub(ImportProductsUseCaseInterface::class));
         $tester->execute([
             '--dir' => $tmpDir,
             '--pattern' => 'products*.csv',
@@ -127,10 +121,7 @@ final class ShopwareProductsImportBatchCommandTest extends TestCase
 
     public function test_missing_directory_returns_failure(): void
     {
-        $tester = $this->makeTester(
-            $this->createStub(ProductCsvReaderInterface::class),
-            $this->createStub(ProductCsvImportRunnerInterface::class),
-        );
+        $tester = $this->makeTester($this->createStub(ImportProductsUseCaseInterface::class));
         $tester->execute([
             '--dir' => '/nonexistent/path/xyz',
             '--processed-dir' => '/tmp/processed',


### PR DESCRIPTION
## Summary

Introduces the `Application/` layer to complete the Hexagonal Architecture.
Commands previously called Infrastructure classes directly — the Use Case moves
orchestration logic one layer up and makes it infrastructure-agnostic.

## Dependency graph before
Command → ProductCsvReader (Infrastructure)
Command → ProductCsvImportRunner (Infrastructure)

## Dependency graph after
Command → ImportProductsUseCaseInterface (Application)
→ ProductReaderInterface (Port)
→ ProductImporterInterface (Port)
→ ProductCsvReader (Infrastructure)
→ ProductCsvImportRunner (Infrastructure)

## New classes

**`ImportProductsUseCase`** (`src/Integration/Application/`)
- Orchestrates reading and importing via port interfaces
- Returns typed `ImportResult` domain value object
- Infrastructure-agnostic — no Shopware-specific code

**`ImportProductsUseCaseInterface`** (`src/Integration/Application/`)
- Required for PHPUnit mocking of the `final` use case class

**`ImportResult`** (`src/Integration/Domain/`)
- Typed value object replacing untyped `array` return from runner
- Provides `hasFailures()` and `summary()` helper methods

**`ProductReaderInterface`** (`src/Integration/Application/Port/`)
- Port for reading product data from any source (CSV, XML, API, ...)

**`ProductImporterInterface`** (`src/Integration/Application/Port/`)
- Port for importing a list of `ProductDraft` objects

## Refactoring

- `ProductCsvReader` implements `ProductReaderInterface`
- `ProductCsvImportRunner` implements `ProductImporterInterface`
- `ShopwareProductsImportCsvCommand` uses `ImportProductsUseCaseInterface`
- `ShopwareProductsImportBatchCommand` uses `ImportProductsUseCaseInterface`
- All new interface bindings added to `services.yaml`

## Tests

- `ShopwareProductsImportBatchCommandTest` refactored to use
  `ImportProductsUseCaseInterface` and `ImportResult`

## Closes

Closes #29