### PR TITLE
M1.9 – Add description and manufacturer fields to CSV import

### DIFF
--- a/src/Integration/Domain/ProductDraft.php
+++ b/src/Integration/Domain/ProductDraft.php
@@ -9,8 +9,8 @@ final readonly class ProductDraft
     public function __construct(
         public string $productNumber,
         public string $name,
-        public string $manufacturer,
-        public string $description,
+        public ?string $manufacturer = null,
+        public ?string $description = null,
         public ?int $stock = null,
         public ?float $gross = null,
         public ?float $net = null,

--- a/src/Integration/Domain/ProductDraft.php
+++ b/src/Integration/Domain/ProductDraft.php
@@ -9,6 +9,8 @@ final readonly class ProductDraft
     public function __construct(
         public string $productNumber,
         public string $name,
+        public string $manufacturer,
+        public string $description,
         public ?int $stock = null,
         public ?float $gross = null,
         public ?float $net = null,

--- a/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReader.php
+++ b/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReader.php
@@ -47,6 +47,8 @@ final class ProductCsvReader implements ProductCsvReaderInterface, ProductReader
 
             $productNumber = trim((string) ($assoc['productNumber'] ?? ''));
             $name = trim((string) ($assoc['name'] ?? ''));
+            $manufacturer = trim((string) ($assoc['manufacturer'] ?? ''));
+            $description = trim((string) ($assoc['description'] ?? ''));
 
             if ($productNumber === '' || $name === '') {
                 continue;
@@ -62,6 +64,8 @@ final class ProductCsvReader implements ProductCsvReaderInterface, ProductReader
             $drafts[] = new ProductDraft(
                 $productNumber,
                 $name,
+                $manufacturer,
+                $description,
                 $stock,
                 $gross,
                 $net,

--- a/src/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidator.php
+++ b/src/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidator.php
@@ -33,7 +33,7 @@ final class ProductDraftValidator implements ProductDraftValidatorInterface
             $errors[] = new ValidationError($rowNumber, $draft->description, 'description','Too long (max 65535 chars)');
         }
 
-// manufacturer: optional, aber wenn gesetzt max. 255
+        // manufacturer: optional, aber wenn gesetzt max. 255
         if ($draft->manufacturer !== null && mb_strlen($draft->manufacturer) > 255) {
             $errors[] = new ValidationError($rowNumber, $draft->manufacturer, 'manufacturer', 'Too long (max 255 chars)');
         }

--- a/src/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidator.php
+++ b/src/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidator.php
@@ -29,6 +29,15 @@ final class ProductDraftValidator implements ProductDraftValidatorInterface
             $errors[] = new ValidationError($rowNumber, $draft->productNumber, 'name', 'required');
         }
 
+        if ($draft->description !== null && mb_strlen($draft->description) > 65535) {
+            $errors[] = new ValidationError($rowNumber, $draft->description, 'description','Too long (max 65535 chars)');
+        }
+
+// manufacturer: optional, aber wenn gesetzt max. 255
+        if ($draft->manufacturer !== null && mb_strlen($draft->manufacturer) > 255) {
+            $errors[] = new ValidationError($rowNumber, $draft->manufacturer, 'manufacturer', 'Too long (max 255 chars)');
+        }
+
         // stock must be non-negative if provided
         if ($draft->stock !== null && $draft->stock < 0) {
             $errors[] = new ValidationError(

--- a/src/Integration/Infrastructure/Shopware/Product/ShopwareProductImportService.php
+++ b/src/Integration/Infrastructure/Shopware/Product/ShopwareProductImportService.php
@@ -109,13 +109,16 @@ final class ShopwareProductImportService implements ShopwareProductImportInterfa
         $payload = [
             'name'          => $draft->name,
             'productNumber' => $draft->productNumber,
-            'manufacturerId'  => $this->resolver->getManufacturerId($draft->manufacturer),
             'description'   => $draft->description,
             'stock'         => $draft->stock ?? self::DEFAULT_STOCK,
             'active'        => $draft->active ?? true,
             // Cast to int: taxRate is ?float in ProductDraft, getTaxId() expects int
             'taxId'         => $this->resolver->getTaxId((int) $effectiveTaxRate),
         ];
+
+        if ($draft->manufacturer !== null) {
+            $payload['manufacturerId'] = $this->resolver->getManufacturerId($draft->manufacturer);
+        }
 
         // Only build price entry if gross is present — Shopware rejects price
         // entries without a gross value
@@ -144,7 +147,7 @@ final class ShopwareProductImportService implements ShopwareProductImportInterfa
      * Values are cast to their expected PHP types to guard against APIs
      * returning numbers as strings (e.g. stock as "0").
      *
-     * @return array{name: string|null, stock: int|null, active: bool|null, gross: float|null}
+     * @return array{name: string|null, manufacturer: string|null, description: string|null, stock: int|null, active: bool|null, gross: float|null}
      */
     private function fetchCurrentData(string $productId): array
     {
@@ -171,7 +174,7 @@ final class ShopwareProductImportService implements ShopwareProductImportInterfa
     /**
      * Compares draft against current Shopware data.
      *
-     * @param array{name: string|null, stock: int|null, active: bool|null, gross: float|null} $current
+     * @param array{name: string|null, manufacturer: string|null, description: string|null, stock: int|null, active: bool|null, gross: float|null} $current
      */
     private function hasChanges(ProductDraft $draft, array $current): bool
     {

--- a/src/Integration/Infrastructure/Shopware/Product/ShopwareProductImportService.php
+++ b/src/Integration/Infrastructure/Shopware/Product/ShopwareProductImportService.php
@@ -109,6 +109,8 @@ final class ShopwareProductImportService implements ShopwareProductImportInterfa
         $payload = [
             'name'          => $draft->name,
             'productNumber' => $draft->productNumber,
+            'manufacturerId'  => $this->resolver->getManufacturerId($draft->manufacturer),
+            'description'   => $draft->description,
             'stock'         => $draft->stock ?? self::DEFAULT_STOCK,
             'active'        => $draft->active ?? true,
             // Cast to int: taxRate is ?float in ProductDraft, getTaxId() expects int
@@ -157,6 +159,8 @@ final class ShopwareProductImportService implements ShopwareProductImportInterfa
 
         return [
             'name'   => is_string($data['name'] ?? null) ? $data['name'] : null,
+            'manufacturer' => is_string($data['manufacturer'] ?? null) ? $data['manufacturer'] : null,
+            'description' => is_string($data['description'] ?? null) ? $data['description'] : null,
             'stock'  => isset($data['stock']) ? (int) $data['stock'] : null,
             'active' => isset($data['active']) ? (bool) $data['active'] : null,
             // First price entry, default currency
@@ -173,6 +177,16 @@ final class ShopwareProductImportService implements ShopwareProductImportInterfa
     {
         // Compare name
         if ($draft->name !== $current['name']) {
+            return true;
+        }
+
+        // Compare manufacturer
+        if ($draft->manufacturer !== $current['manufacturer']) {
+            return true;
+        }
+
+        // Compare description
+        if ($draft->description !== $current['description']) {
             return true;
         }
 

--- a/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolver.php
+++ b/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolver.php
@@ -14,6 +14,9 @@ final class ShopwareReferenceDataResolver implements ShopwareReferenceDataResolv
     // Cache keyed by tax rate, e.g. [19 => 'uuid...', 7 => 'uuid...']
     private array $taxIds = [];
 
+    // Cache keyed by name, e.g. ['ABC' => 'uuid...']
+    private array $manufacturerIds = [];
+
     public function __construct(
         private readonly ShopwareAdminApiClientInterface $client,
     ) {}
@@ -79,5 +82,34 @@ final class ShopwareReferenceDataResolver implements ShopwareReferenceDataResolv
         }
 
         return $this->taxIds[$taxRate] = $id;
+    }
+
+    public function getManufacturerId(string $name): string
+    {
+        if (isset($this->manufacturerIds[$name])) {
+            return $this->manufacturerIds[$name];
+        }
+
+        $res = $this->client->requestOrFail(
+            method: 'POST',
+            path: '/api/search/product-manufacturer',
+            json: [
+                'limit' => 1,
+                'filter' => [[
+                    'type'  => 'equals',
+                    'field' => 'name',
+                    'value' => $name,
+                ]],
+                'includes' => ['product_manufacturer' => ['id', 'name']],
+            ],
+            authenticated: true
+        );
+
+        $id = $res['body']['data'][0]['id'] ?? null;
+        if (!is_string($id) || $id === '') {
+            throw new \RuntimeException(sprintf('Could not resolve manufacturerId for "%s".', $name));
+        }
+
+        return $this->manufacturerIds[$name] = $id;
     }
 }

--- a/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolverInterface.php
+++ b/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolverInterface.php
@@ -8,4 +8,6 @@ interface ShopwareReferenceDataResolverInterface
 {
     public function getCurrencyId(?string $currency = null): string;
     public function getTaxId(int $taxRate = 19): string;
+
+    public function getManufacturerId(string $manufacturerName): string;
 }

--- a/tests/Integration/Infrastructure/Shopware/Product/Import/ProductCsvImportRunnerTest.php
+++ b/tests/Integration/Infrastructure/Shopware/Product/Import/ProductCsvImportRunnerTest.php
@@ -99,8 +99,8 @@ final class ProductCsvImportRunnerTest extends TestCase
         $runner = new ProductCsvImportRunner($service, $validator);
 
         $drafts = [
-            new ProductDraft('IMP-601', 'Product 601', null, null, 8.39),
-            new ProductDraft('IMP-602', 'Product 602', 5, 9.99),
+            new ProductDraft('IMP-601', 'Product 601', null, null, null, null, 8.39),
+            new ProductDraft('IMP-602', 'Product 602', null, null, 5, 9.99),
         ];
 
         $summary = $runner->importDrafts($drafts);
@@ -122,7 +122,7 @@ final class ProductCsvImportRunnerTest extends TestCase
 
         $runner = new ProductCsvImportRunner($service, $validator);
 
-        $drafts = [new ProductDraft('IMP-701', 'Product 701', null, null, 8.39)];
+        $drafts = [new ProductDraft('IMP-701', 'Product 701', null, null, null, null, 8.39)];
         $summary = $runner->importDrafts($drafts);
 
         self::assertStringStartsWith('validation:', $summary['results'][0]['action']);

--- a/tests/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidatorTest.php
+++ b/tests/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidatorTest.php
@@ -19,7 +19,7 @@ final class ProductDraftValidatorTest extends TestCase
 
     public function test_valid_draft_returns_no_errors(): void
     {
-        $draft = new ProductDraft('IMP-101', 'Product 101', 10, 19.99, null, 19.0, 'EUR', true);
+        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, 10, 19.99, null, 19.0, 'EUR', true);
         $errors = $this->validator->validate($draft, 2);
 
         self::assertCount(0, $errors);
@@ -27,7 +27,7 @@ final class ProductDraftValidatorTest extends TestCase
 
     public function test_negative_stock_returns_error(): void
     {
-        $draft = new ProductDraft('IMP-101', 'Product 101', -1, 19.99);
+        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, -1, 19.99);
         $errors = $this->validator->validate($draft, 2);
 
         self::assertCount(1, $errors);
@@ -39,7 +39,7 @@ final class ProductDraftValidatorTest extends TestCase
     public function test_net_without_gross_returns_error(): void
     {
         // net provided but gross is null → price entry would be incomplete
-        $draft = new ProductDraft('IMP-102', 'Product 102', null, null, 8.39);
+        $draft = new ProductDraft('IMP-102', 'Product 102', null, null, null, null, 8.39);
         $errors = $this->validator->validate($draft, 3);
 
         self::assertCount(1, $errors);
@@ -49,7 +49,7 @@ final class ProductDraftValidatorTest extends TestCase
 
     public function test_zero_tax_rate_returns_error(): void
     {
-        $draft = new ProductDraft('IMP-103', 'Product 103', null, 9.99, null, 0.0);
+        $draft = new ProductDraft('IMP-103', 'Product 103', null, null, null, 9.99, null, 0.0);
         $errors = $this->validator->validate($draft, 4);
 
         self::assertCount(1, $errors);
@@ -58,7 +58,7 @@ final class ProductDraftValidatorTest extends TestCase
 
     public function test_negative_tax_rate_returns_error(): void
     {
-        $draft = new ProductDraft('IMP-104', 'Product 104', null, 9.99, null, -7.0);
+        $draft = new ProductDraft('IMP-104', 'Product 104', null, null, null, 9.99, null, -7.0);
         $errors = $this->validator->validate($draft, 5);
 
         self::assertCount(1, $errors);
@@ -68,7 +68,7 @@ final class ProductDraftValidatorTest extends TestCase
     public function test_multiple_errors_are_collected(): void
     {
         // negative stock AND net without gross → two errors at once
-        $draft = new ProductDraft('IMP-105', 'Product 105', -5, null, 8.39);
+        $draft = new ProductDraft('IMP-105', 'Product 105', null, null, -5, null, 8.39);
         $errors = $this->validator->validate($draft, 6);
 
         self::assertCount(2, $errors);
@@ -89,7 +89,7 @@ final class ProductDraftValidatorTest extends TestCase
 
     public function test_error_to_string_format(): void
     {
-        $draft = new ProductDraft('IMP-107', 'Product 107', -1);
+        $draft = new ProductDraft('IMP-107', 'Product 107', null, null, -1);
         $errors = $this->validator->validate($draft, 2);
 
         self::assertCount(1, $errors);

--- a/tests/Integration/Infrastructure/Shopware/Product/Import/ShopwareProductImportServiceTest.php
+++ b/tests/Integration/Infrastructure/Shopware/Product/Import/ShopwareProductImportServiceTest.php
@@ -43,7 +43,7 @@ final class ShopwareProductImportServiceTest extends TestCase
                 return ['body' => []]; // create call
             });
 
-        $draft = new ProductDraft('IMP-NEW', 'New Product', 5, 19.99, null, 19.0, 'EUR', true);
+        $draft = new ProductDraft('IMP-NEW', 'New Product', null, null, 5, 19.99, null, 19.0, 'EUR', true);
         $result = $this->service->upsert($draft);
 
         self::assertSame('create', $result);
@@ -60,7 +60,7 @@ final class ShopwareProductImportServiceTest extends TestCase
                 return ['body' => []]; // patch call
             });
 
-        $draft = new ProductDraft('IMP-101', 'Updated Product', 10, 29.99, null, 19.0, 'EUR', true);
+        $draft = new ProductDraft('IMP-101', 'Updated Product', null, null, 10, 29.99, null, 19.0, 'EUR', true);
         $result = $this->service->upsert($draft);
 
         self::assertSame('update', $result);
@@ -102,7 +102,7 @@ final class ShopwareProductImportServiceTest extends TestCase
             );
 
         // gross=9.99, net=null → net should be calculated as 9.99 / 1.19 = 8.3950
-        $draft = new ProductDraft('IMP-CALC', 'Calc Product', null, 9.99, null, 19.0);
+        $draft = new ProductDraft('IMP-CALC', 'Calc Product', null, null, null, 9.99, null, 19.0);
         $this->service->upsert($draft);
 
         self::assertNotNull($capturedPayload);
@@ -127,7 +127,7 @@ final class ShopwareProductImportServiceTest extends TestCase
             );
 
         // active=null → should default to true in payload
-        $draft = new ProductDraft('IMP-ACTIVE', 'Active Product', null, 9.99, null, 19.0, null, null);
+        $draft = new ProductDraft('IMP-ACTIVE', 'Active Product', null, null, null, 9.99, null, 19.0, null, null);
         $this->service->upsert($draft);
 
         self::assertTrue($capturedPayload['active']);
@@ -176,7 +176,7 @@ final class ShopwareProductImportServiceTest extends TestCase
             });
 
         // Draft matches current Shopware data exactly → should be skipped
-        $draft = new ProductDraft('IMP-101', 'Product 101', 10, 19.99, null, 19.0, 'EUR', true);
+        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, 10, 19.99, null, 19.0, 'EUR', true);
         $result = $this->service->upsert($draft);
 
         self::assertSame('skipped', $result);
@@ -202,7 +202,7 @@ final class ShopwareProductImportServiceTest extends TestCase
             });
 
         // stock changed from 10 to 20 → should update
-        $draft = new ProductDraft('IMP-101', 'Product 101', 20, 19.99, null, 19.0, 'EUR', true);
+        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, 20, 19.99, null, 19.0, 'EUR', true);
         $result = $this->service->upsert($draft);
 
         self::assertSame('update', $result);
@@ -228,7 +228,7 @@ final class ShopwareProductImportServiceTest extends TestCase
             });
 
         // active changed to false → should update
-        $draft = new ProductDraft('IMP-101', 'Product 101', 10, 19.99, null, 19.0, 'EUR', false);
+        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, 10, 19.99, null, 19.0, 'EUR', false);
         $result = $this->service->upsert($draft);
 
         self::assertSame('update', $result);
@@ -257,7 +257,7 @@ final class ShopwareProductImportServiceTest extends TestCase
 
         $service = new ShopwareProductImportService($client, $this->resolver);
 
-        $draft = new ProductDraft('IMP-101', 'Product 101', 10, 19.99, null, 19.0, 'EUR', true);
+        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, 10, 19.99, null, 19.0, 'EUR', true);
         $result = $service->upsert($draft, dryRun: true);
 
         self::assertSame('skipped', $result);


### PR DESCRIPTION
## Summary
Extends the CSV import pipeline with two new optional fields: 
`description` and `manufacturer`.

## Changes
- `ProductDraft`: new optional fields `manufacturer` and `description`
- `ProductCsvReader`: maps new CSV columns
- `ShopwareReferenceDataResolver`: adds `getManufacturerId()` via `/api/search/product-manufacturer`
- `ShopwareProductImportService`: resolves `manufacturerId`, adds `description` to payload, extends `hasChanges()`
- `ProductDraftValidator`: max-255 validation for manufacturer name
- All tests updated, 44/44 green, PHPStan level 5 clean

## Notes
- `manufacturerId` is only added to payload if manufacturer is set
- Manufacturer must exist in Shopware before import (no auto-create)
- Description has no length validation (LONGTEXT in DB)

## Testing
Manually tested with two products including manufacturer lookup and 
description – both imported successfully into Shopware.