### PR TITLE
M1.10 – Auto-assign Sales Channel visibility and category on import

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,8 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    integration.adapters.shopware.default_tax_rate: 19
+    integration.adapters.shopware.default_sales_channel_id: '%env(resolve:SHOPWARE_SALES_CHANNEL_ID)%'
 
 services:
     # default configuration for services in *this* file
@@ -36,6 +38,11 @@ services:
             $baseUrl: '%integration.adapters.shopware.base_url%'
             $clientId: '%env(resolve:SHOPWARE_CLIENT_ID)%'
             $clientSecret: '%env(resolve:SHOPWARE_CLIENT_SECRET)%'
+
+    App\Integration\Infrastructure\Shopware\Product\ShopwareProductImportService:
+        arguments:
+            $defaultTaxRate: '%integration.adapters.shopware.default_tax_rate%'
+            $defaultSalesChannelId: '%integration.adapters.shopware.default_sales_channel_id%'
 
     App\Integration\Application\ImportProductsUseCaseInterface: '@App\Integration\Application\ImportProductsUseCase'
     App\Integration\Application\Port\ProductReaderInterface: '@App\Integration\Infrastructure\Shopware\Product\Import\ProductCsvReader'

--- a/src/Integration/Domain/ProductDraft.php
+++ b/src/Integration/Domain/ProductDraft.php
@@ -11,6 +11,7 @@ final readonly class ProductDraft
         public string $name,
         public ?string $manufacturer = null,
         public ?string $description = null,
+        public array $categories = [],
         public ?int $stock = null,
         public ?float $gross = null,
         public ?float $net = null,

--- a/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReader.php
+++ b/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReader.php
@@ -49,8 +49,9 @@ final class ProductCsvReader implements ProductCsvReaderInterface, ProductReader
             $name = trim((string) ($assoc['name'] ?? ''));
             $manufacturer = trim((string) ($assoc['manufacturer'] ?? ''));
             $description = trim((string) ($assoc['description'] ?? ''));
-            $categories = $assoc['category'] !== '' && $assoc['category'] !== null
-                ? array_map('trim', explode(';', (string) $assoc['category']))
+            $categoryRaw = $assoc['category'] ?? null;
+            $categories = $categoryRaw !== null && $categoryRaw !== ''
+                ? array_map('trim', explode(';', (string) $categoryRaw))
                 : [];
 
             if ($productNumber === '' || $name === '') {

--- a/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReader.php
+++ b/src/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReader.php
@@ -49,6 +49,9 @@ final class ProductCsvReader implements ProductCsvReaderInterface, ProductReader
             $name = trim((string) ($assoc['name'] ?? ''));
             $manufacturer = trim((string) ($assoc['manufacturer'] ?? ''));
             $description = trim((string) ($assoc['description'] ?? ''));
+            $categories = $assoc['category'] !== '' && $assoc['category'] !== null
+                ? array_map('trim', explode(';', (string) $assoc['category']))
+                : [];
 
             if ($productNumber === '' || $name === '') {
                 continue;
@@ -66,6 +69,7 @@ final class ProductCsvReader implements ProductCsvReaderInterface, ProductReader
                 $name,
                 $manufacturer,
                 $description,
+                $categories,
                 $stock,
                 $gross,
                 $net,

--- a/src/Integration/Infrastructure/Shopware/Product/ShopwareProductImportService.php
+++ b/src/Integration/Infrastructure/Shopware/Product/ShopwareProductImportService.php
@@ -15,8 +15,8 @@ final class ShopwareProductImportService implements ShopwareProductImportInterfa
     public function __construct(
         private readonly ShopwareAdminApiClientInterface $client,
         private readonly ShopwareReferenceDataResolverInterface $resolver,
-        // Configurable via services.yaml: $defaultTaxRate: '%integration.adapters.shopware.default_tax_rate%'
         private readonly int $defaultTaxRate = 19,
+        private readonly string $defaultSalesChannelId = '',
     ) {}
 
     /**
@@ -64,7 +64,7 @@ final class ShopwareProductImportService implements ShopwareProductImportInterfa
                 $this->client->requestOrFail(
                     method: 'POST',
                     path: '/api/product',
-                    json: $this->buildPayload($draft),
+                    json: $this->buildPayload($draft, isNew: true),
                     authenticated: true
                 );
             }
@@ -81,7 +81,7 @@ final class ShopwareProductImportService implements ShopwareProductImportInterfa
             $this->client->requestOrFail(
                 method: 'PATCH',
                 path: '/api/product/' . $existingId,
-                json: $this->buildPayload($draft),
+                json: $this->buildPayload($draft, isNew: false),
                 authenticated: true
             );
         }
@@ -101,7 +101,7 @@ final class ShopwareProductImportService implements ShopwareProductImportInterfa
      *
      * @return array<string, mixed>
      */
-    private function buildPayload(ProductDraft $draft): array
+    private function buildPayload(ProductDraft $draft, bool $isNew = false): array
     {
         // Use taxRate from draft or fallback to default (e.g. 19%)
         $effectiveTaxRate = $draft->taxRate ?? $this->defaultTaxRate;
@@ -120,6 +120,13 @@ final class ShopwareProductImportService implements ShopwareProductImportInterfa
             $payload['manufacturerId'] = $this->resolver->getManufacturerId($draft->manufacturer);
         }
 
+        if ($draft->categories !== []) {
+            $payload['categories'] = array_map(
+                fn(string $name) => ['id' => $this->resolver->getCategoryId($name)],
+                $draft->categories
+            );
+        }
+
         // Only build price entry if gross is present — Shopware rejects price
         // entries without a gross value
         if ($draft->gross !== null) {
@@ -136,6 +143,13 @@ final class ShopwareProductImportService implements ShopwareProductImportInterfa
                 // linked: false = gross and net are independent values;
                 // linked: true would let Shopware auto-calculate net from gross
                 'linked'     => false,
+            ]];
+        }
+
+        if ($isNew) {
+            $payload['visibilities'] = [[
+                'salesChannelId' => $this->defaultSalesChannelId,
+                'visibility' => 30,
             ]];
         }
 

--- a/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolver.php
+++ b/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolver.php
@@ -17,6 +17,8 @@ final class ShopwareReferenceDataResolver implements ShopwareReferenceDataResolv
     // Cache keyed by name, e.g. ['ABC' => 'uuid...']
     private array $manufacturerIds = [];
 
+    private array $categoryIds = [];
+
     public function __construct(
         private readonly ShopwareAdminApiClientInterface $client,
     ) {}
@@ -107,9 +109,44 @@ final class ShopwareReferenceDataResolver implements ShopwareReferenceDataResolv
 
         $id = $res['body']['data'][0]['id'] ?? null;
         if (!is_string($id) || $id === '') {
-            throw new \RuntimeException(sprintf('Could not resolve manufacturerId for "%s".', $name));
+            throw new \RuntimeException(sprintf(
+                'Could not resolve manufacturerId for "%s". Make sure the manufacturer exists in Shopware before importing.',
+                $name
+            ));
         }
 
         return $this->manufacturerIds[$name] = $id;
+    }
+
+    public function getCategoryId(string $name): string
+    {
+        if (isset($this->categoryIds[$name])) {
+            return $this->categoryIds[$name];
+        }
+
+        $res = $this->client->requestOrFail(
+            method: 'POST',
+            path: '/api/search/category',
+            json: [
+                'limit' => 1,
+                'filter' => [[
+                    'type'  => 'equals',
+                    'field' => 'name',
+                    'value' => $name,
+                ]],
+                'includes' => ['category' => ['id', 'name']],
+            ],
+            authenticated: true
+        );
+
+        $id = $res['body']['data'][0]['id'] ?? null;
+        if (!is_string($id) || $id === '') {
+            throw new \RuntimeException(sprintf(
+                'Could not resolve categoryId for "%s". Make sure the category exists in Shopware before importing.',
+                $name
+            ));
+        }
+
+        return $this->categoryIds[$name] = $id;
     }
 }

--- a/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolverInterface.php
+++ b/src/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolverInterface.php
@@ -10,4 +10,6 @@ interface ShopwareReferenceDataResolverInterface
     public function getTaxId(int $taxRate = 19): string;
 
     public function getManufacturerId(string $manufacturerName): string;
+
+    public function getCategoryId(string $name): string;
 }

--- a/tests/Integration/Infrastructure/Shopware/Product/Import/ProductCsvImportRunnerTest.php
+++ b/tests/Integration/Infrastructure/Shopware/Product/Import/ProductCsvImportRunnerTest.php
@@ -99,8 +99,8 @@ final class ProductCsvImportRunnerTest extends TestCase
         $runner = new ProductCsvImportRunner($service, $validator);
 
         $drafts = [
-            new ProductDraft('IMP-601', 'Product 601', null, null, null, null, 8.39),
-            new ProductDraft('IMP-602', 'Product 602', null, null, 5, 9.99),
+            new ProductDraft('IMP-601', 'Product 601', null, null, [], null, null, 8.39),
+            new ProductDraft('IMP-602', 'Product 602', null, null, [], 5, 9.99),
         ];
 
         $summary = $runner->importDrafts($drafts);
@@ -122,7 +122,7 @@ final class ProductCsvImportRunnerTest extends TestCase
 
         $runner = new ProductCsvImportRunner($service, $validator);
 
-        $drafts = [new ProductDraft('IMP-701', 'Product 701', null, null, null, null, 8.39)];
+        $drafts = [new ProductDraft('IMP-701', 'Product 701', null, null, [], null, null, 8.39)];
         $summary = $runner->importDrafts($drafts);
 
         self::assertStringStartsWith('validation:', $summary['results'][0]['action']);

--- a/tests/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReaderTest.php
+++ b/tests/Integration/Infrastructure/Shopware/Product/Import/ProductCsvReaderTest.php
@@ -113,4 +113,58 @@ final class ProductCsvReaderTest extends TestCase
 
         @unlink($tmp);
     }
+
+    public function test_reads_single_category_from_csv(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'csv_');
+        self::assertNotFalse($tmp);
+
+        file_put_contents($tmp, implode("\n", [
+            'productNumber,name,category',
+            'IMP-801,Product 801,Electronics',
+        ]));
+
+        $drafts = (new ProductCsvReader())->read($tmp);
+
+        self::assertCount(1, $drafts);
+        self::assertSame(['Electronics'], $drafts[0]->categories);
+
+        @unlink($tmp);
+    }
+
+    public function test_reads_multiple_categories_separated_by_semicolons(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'csv_');
+        self::assertNotFalse($tmp);
+
+        file_put_contents($tmp, implode("\n", [
+            'productNumber,name,category',
+            'IMP-802,Product 802,Electronics;Featured',
+        ]));
+
+        $drafts = (new ProductCsvReader())->read($tmp);
+
+        self::assertCount(1, $drafts);
+        self::assertSame(['Electronics', 'Featured'], $drafts[0]->categories);
+
+        @unlink($tmp);
+    }
+
+    public function test_empty_category_column_produces_empty_array(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'csv_');
+        self::assertNotFalse($tmp);
+
+        file_put_contents($tmp, implode("\n", [
+            'productNumber,name,category',
+            'IMP-803,Product 803,',
+        ]));
+
+        $drafts = (new ProductCsvReader())->read($tmp);
+
+        self::assertCount(1, $drafts);
+        self::assertSame([], $drafts[0]->categories);
+
+        @unlink($tmp);
+    }
 }

--- a/tests/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidatorTest.php
+++ b/tests/Integration/Infrastructure/Shopware/Product/Import/ProductDraftValidatorTest.php
@@ -19,7 +19,7 @@ final class ProductDraftValidatorTest extends TestCase
 
     public function test_valid_draft_returns_no_errors(): void
     {
-        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, 10, 19.99, null, 19.0, 'EUR', true);
+        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, [], 10, 19.99, null, 19.0, 'EUR', true);
         $errors = $this->validator->validate($draft, 2);
 
         self::assertCount(0, $errors);
@@ -27,7 +27,7 @@ final class ProductDraftValidatorTest extends TestCase
 
     public function test_negative_stock_returns_error(): void
     {
-        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, -1, 19.99);
+        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, [], -1, 19.99);
         $errors = $this->validator->validate($draft, 2);
 
         self::assertCount(1, $errors);
@@ -39,7 +39,7 @@ final class ProductDraftValidatorTest extends TestCase
     public function test_net_without_gross_returns_error(): void
     {
         // net provided but gross is null → price entry would be incomplete
-        $draft = new ProductDraft('IMP-102', 'Product 102', null, null, null, null, 8.39);
+        $draft = new ProductDraft('IMP-102', 'Product 102', null, null, [], null, null, 8.39);
         $errors = $this->validator->validate($draft, 3);
 
         self::assertCount(1, $errors);
@@ -49,7 +49,7 @@ final class ProductDraftValidatorTest extends TestCase
 
     public function test_zero_tax_rate_returns_error(): void
     {
-        $draft = new ProductDraft('IMP-103', 'Product 103', null, null, null, 9.99, null, 0.0);
+        $draft = new ProductDraft('IMP-103', 'Product 103', null, null, [], null, 9.99, null, 0.0);
         $errors = $this->validator->validate($draft, 4);
 
         self::assertCount(1, $errors);
@@ -58,7 +58,7 @@ final class ProductDraftValidatorTest extends TestCase
 
     public function test_negative_tax_rate_returns_error(): void
     {
-        $draft = new ProductDraft('IMP-104', 'Product 104', null, null, null, 9.99, null, -7.0);
+        $draft = new ProductDraft('IMP-104', 'Product 104', null, null, [], null, 9.99, null, -7.0);
         $errors = $this->validator->validate($draft, 5);
 
         self::assertCount(1, $errors);
@@ -68,7 +68,7 @@ final class ProductDraftValidatorTest extends TestCase
     public function test_multiple_errors_are_collected(): void
     {
         // negative stock AND net without gross → two errors at once
-        $draft = new ProductDraft('IMP-105', 'Product 105', null, null, -5, null, 8.39);
+        $draft = new ProductDraft('IMP-105', 'Product 105', null, null, [], -5, null, 8.39);
         $errors = $this->validator->validate($draft, 6);
 
         self::assertCount(2, $errors);
@@ -89,7 +89,7 @@ final class ProductDraftValidatorTest extends TestCase
 
     public function test_error_to_string_format(): void
     {
-        $draft = new ProductDraft('IMP-107', 'Product 107', null, null, -1);
+        $draft = new ProductDraft('IMP-107', 'Product 107', null, null, [], -1);
         $errors = $this->validator->validate($draft, 2);
 
         self::assertCount(1, $errors);

--- a/tests/Integration/Infrastructure/Shopware/Product/Import/ShopwareProductImportServiceTest.php
+++ b/tests/Integration/Infrastructure/Shopware/Product/Import/ShopwareProductImportServiceTest.php
@@ -43,7 +43,7 @@ final class ShopwareProductImportServiceTest extends TestCase
                 return ['body' => []]; // create call
             });
 
-        $draft = new ProductDraft('IMP-NEW', 'New Product', null, null, 5, 19.99, null, 19.0, 'EUR', true);
+        $draft = new ProductDraft('IMP-NEW', 'New Product', null, null, [], 5, 19.99, null, 19.0, 'EUR', true);
         $result = $this->service->upsert($draft);
 
         self::assertSame('create', $result);
@@ -60,7 +60,7 @@ final class ShopwareProductImportServiceTest extends TestCase
                 return ['body' => []]; // patch call
             });
 
-        $draft = new ProductDraft('IMP-101', 'Updated Product', null, null, 10, 29.99, null, 19.0, 'EUR', true);
+        $draft = new ProductDraft('IMP-101', 'Updated Product', null, null, [], 10, 29.99, null, 19.0, 'EUR', true);
         $result = $this->service->upsert($draft);
 
         self::assertSame('update', $result);
@@ -102,7 +102,7 @@ final class ShopwareProductImportServiceTest extends TestCase
             );
 
         // gross=9.99, net=null → net should be calculated as 9.99 / 1.19 = 8.3950
-        $draft = new ProductDraft('IMP-CALC', 'Calc Product', null, null, null, 9.99, null, 19.0);
+        $draft = new ProductDraft('IMP-CALC', 'Calc Product', null, null, [], null, 9.99, null, 19.0);
         $this->service->upsert($draft);
 
         self::assertNotNull($capturedPayload);
@@ -127,7 +127,7 @@ final class ShopwareProductImportServiceTest extends TestCase
             );
 
         // active=null → should default to true in payload
-        $draft = new ProductDraft('IMP-ACTIVE', 'Active Product', null, null, null, 9.99, null, 19.0, null, null);
+        $draft = new ProductDraft('IMP-ACTIVE', 'Active Product', null, null, [], null, 9.99, null, 19.0, null, null);
         $this->service->upsert($draft);
 
         self::assertTrue($capturedPayload['active']);
@@ -176,7 +176,7 @@ final class ShopwareProductImportServiceTest extends TestCase
             });
 
         // Draft matches current Shopware data exactly → should be skipped
-        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, 10, 19.99, null, 19.0, 'EUR', true);
+        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, [], 10, 19.99, null, 19.0, 'EUR', true);
         $result = $this->service->upsert($draft);
 
         self::assertSame('skipped', $result);
@@ -202,7 +202,7 @@ final class ShopwareProductImportServiceTest extends TestCase
             });
 
         // stock changed from 10 to 20 → should update
-        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, 20, 19.99, null, 19.0, 'EUR', true);
+        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, [], 20, 19.99, null, 19.0, 'EUR', true);
         $result = $this->service->upsert($draft);
 
         self::assertSame('update', $result);
@@ -228,7 +228,7 @@ final class ShopwareProductImportServiceTest extends TestCase
             });
 
         // active changed to false → should update
-        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, 10, 19.99, null, 19.0, 'EUR', false);
+        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, [], 10, 19.99, null, 19.0, 'EUR', false);
         $result = $this->service->upsert($draft);
 
         self::assertSame('update', $result);
@@ -257,9 +257,136 @@ final class ShopwareProductImportServiceTest extends TestCase
 
         $service = new ShopwareProductImportService($client, $this->resolver);
 
-        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, 10, 19.99, null, 19.0, 'EUR', true);
+        $draft = new ProductDraft('IMP-101', 'Product 101', null, null, [], 10, 19.99, null, 19.0, 'EUR', true);
         $result = $service->upsert($draft, dryRun: true);
 
         self::assertSame('skipped', $result);
+    }
+
+    public function test_empty_categories_not_in_payload(): void
+    {
+        $capturedPayload = null;
+
+        $this->client
+            ->method('requestOrFail')
+            ->willReturnCallback(
+                function (string $method, string $path, array $json) use (&$capturedPayload): array {
+                    if ($method === 'POST' && str_contains($path, 'search/product')) {
+                        return ['body' => ['data' => []]];
+                    }
+                    $capturedPayload = $json;
+                    return ['body' => []];
+                }
+            );
+
+        // categories = [] (default) → no 'categories' key in payload
+        $draft = new ProductDraft('IMP-NOCAT', 'No Cat Product');
+        $this->service->upsert($draft);
+
+        self::assertNotNull($capturedPayload);
+        self::assertArrayNotHasKey('categories', $capturedPayload);
+    }
+
+    public function test_categories_are_mapped_to_ids_in_payload(): void
+    {
+        $capturedPayload = null;
+
+        $this->client
+            ->method('requestOrFail')
+            ->willReturnCallback(
+                function (string $method, string $path, array $json) use (&$capturedPayload): array {
+                    if ($method === 'POST' && str_contains($path, 'search/product')) {
+                        return ['body' => ['data' => []]];
+                    }
+                    $capturedPayload = $json;
+                    return ['body' => []];
+                }
+            );
+
+        $this->resolver->method('getCategoryId')
+            ->willReturnCallback(static fn(string $name): string => match ($name) {
+                'Electronics' => 'cat-uuid-1',
+                'Featured'    => 'cat-uuid-2',
+                default       => 'cat-uuid-unknown',
+            });
+
+        $draft = new ProductDraft('IMP-CAT', 'Cat Product', null, null, ['Electronics', 'Featured']);
+        $this->service->upsert($draft);
+
+        self::assertNotNull($capturedPayload);
+        self::assertSame(
+            [['id' => 'cat-uuid-1'], ['id' => 'cat-uuid-2']],
+            $capturedPayload['categories']
+        );
+    }
+
+    public function test_visibilities_are_set_for_new_product(): void
+    {
+        $capturedPayload = null;
+
+        $this->client
+            ->method('requestOrFail')
+            ->willReturnCallback(
+                function (string $method, string $path, array $json) use (&$capturedPayload): array {
+                    if ($method === 'POST' && str_contains($path, 'search/product')) {
+                        return ['body' => ['data' => []]];
+                    }
+                    $capturedPayload = $json;
+                    return ['body' => []];
+                }
+            );
+
+        $service = new ShopwareProductImportService(
+            $this->client,
+            $this->resolver,
+            defaultSalesChannelId: 'sc-uuid-123'
+        );
+
+        $draft = new ProductDraft('IMP-VIS', 'Vis Product');
+        $service->upsert($draft);
+
+        self::assertNotNull($capturedPayload);
+        self::assertSame(
+            [['salesChannelId' => 'sc-uuid-123', 'visibility' => 30]],
+            $capturedPayload['visibilities']
+        );
+    }
+
+    public function test_visibilities_not_set_on_update(): void
+    {
+        $capturedPayload = null;
+
+        $this->client
+            ->method('requestOrFail')
+            ->willReturnCallback(
+                function (string $method, string $path, array $json) use (&$capturedPayload): array {
+                    if ($method === 'POST' && str_contains($path, 'search/product')) {
+                        return ['body' => ['data' => [['id' => 'existing-uuid']]]];
+                    }
+                    if ($method === 'GET') {
+                        return ['body' => ['data' => ['attributes' => [
+                            'name'   => 'Update Me',
+                            'stock'  => 5,   // differs from draft stock=10 → triggers update
+                            'active' => true,
+                        ]]]];
+                    }
+                    // PATCH call — capture payload
+                    $capturedPayload = $json;
+                    return ['body' => []];
+                }
+            );
+
+        $service = new ShopwareProductImportService(
+            $this->client,
+            $this->resolver,
+            defaultSalesChannelId: 'sc-uuid-123'
+        );
+
+        // stock differs (10 vs 5) → PATCH is triggered
+        $draft = new ProductDraft('IMP-UPD', 'Update Me', null, null, [], 10);
+        $service->upsert($draft);
+
+        self::assertNotNull($capturedPayload);
+        self::assertArrayNotHasKey('visibilities', $capturedPayload);
     }
 }

--- a/tests/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolverTest.php
+++ b/tests/Integration/Infrastructure/Shopware/ReferenceData/ShopwareReferenceDataResolverTest.php
@@ -127,4 +127,45 @@ final class ShopwareReferenceDataResolverTest extends TestCase
 
         (new ShopwareReferenceDataResolver($client))->getTaxId(99);
     }
+
+    public function test_getCategoryId_resolves_uuid_from_api(): void
+    {
+        $client = $this->createMock(ShopwareAdminApiClientInterface::class);
+        $client
+            ->expects(self::once())
+            ->method('requestOrFail')
+            ->willReturn(['status' => 200, 'raw' => '', 'body' => ['data' => [['id' => 'cat-uuid-123']]]]);
+
+        $id = (new ShopwareReferenceDataResolver($client))->getCategoryId('Electronics');
+
+        self::assertSame('cat-uuid-123', $id);
+    }
+
+    public function test_getCategoryId_caches_result(): void
+    {
+        // API is called only once despite two getCategoryId() invocations
+        $client = $this->createMock(ShopwareAdminApiClientInterface::class);
+        $client
+            ->expects(self::once())
+            ->method('requestOrFail')
+            ->willReturn(['status' => 200, 'raw' => '', 'body' => ['data' => [['id' => 'cat-uuid-123']]]]);
+
+        $resolver = new ShopwareReferenceDataResolver($client);
+        $resolver->getCategoryId('Electronics');
+        $id = $resolver->getCategoryId('Electronics');
+
+        self::assertSame('cat-uuid-123', $id);
+    }
+
+    public function test_getCategoryId_throws_when_not_found(): void
+    {
+        $client = $this->createStub(ShopwareAdminApiClientInterface::class);
+        $client->method('requestOrFail')
+            ->willReturn(['status' => 200, 'raw' => '', 'body' => ['data' => []]]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/categoryId/');
+
+        (new ShopwareReferenceDataResolver($client))->getCategoryId('NonExistent');
+    }
 }


### PR DESCRIPTION
## Summary
Products are now automatically visible in the Storefront and assigned 
to the correct category on import — no manual post-processing needed.

## Changes
- ProductDraft: new categories (array) property
- ProductCsvReader: parses category column (semicolon-separated)
- ShopwareReferenceDataResolver: getCategoryId() with caching
- ShopwareProductImportService: visibilities on CREATE only, 
  categoryIds resolved from draft
- services.yaml + .env: salesChannelId as environment parameter

## Testing
- 54/54 tests green, PHPStan level 5 clean
- Manually tested: 2 new products created with correct category 
  assignment and Storefront visibility